### PR TITLE
0px bug removal

### DIFF
--- a/ReduxCore/inc/fields/typography/field_typography.js
+++ b/ReduxCore/inc/fields/typography/field_typography.js
@@ -169,8 +169,16 @@ jQuery(document).ready(function($) {
 		$('#' + mainID + ' .typography-preview').css('line-height', height + units);
 		$('#' + mainID + ' .typography-preview').css('word-spacing', word + units);
 		$('#' + mainID + ' .typography-preview').css('letter-spacing', letter + units);
-		$('#' + mainID + ' .typography-font-size').val(size + units);
-		$('#' + mainID + ' .typography-line-height').val(height + units);
+		if( size == '' ){
+			$('#' + mainID + ' .typography-font-size').val( '' );
+		}else{
+			$('#' + mainID + ' .typography-font-size').val(size + units);
+		}
+		if( height == '' ){
+			$('#' + mainID + ' .typography-line-height').val( '' );
+		}else{
+			$('#' + mainID + ' .typography-line-height').val(height + units);
+		}
 		$('#' + mainID + ' .typography-word-spacing').val(word + units);
 		$('#' + mainID + ' .typography-letter-spacing').val(letter + units);
 


### PR DESCRIPTION
When you enter empty value for line-height or font-size it still outputs the px value. This patch removes this problem.
