### PR TITLE
Pass options as a ref so validating actions can modify/sanitize them

### DIFF
--- a/ReduxCore/framework.php
+++ b/ReduxCore/framework.php
@@ -1471,7 +1471,7 @@ if( !class_exists( 'ReduxFramework' ) ) {
             	set_transient( 'redux-warnings-' . $this->args['opt_name'], $this->warnings, 1000 );
             }               
 
-            do_action( 'redux-validate-' . $this->args['opt_name'], $plugin_options, $this->options );
+            do_action_ref_array('redux-validate-' . $this->args['opt_name'], array(&$plugin_options, $this->options));
 
             if( !empty( $plugin_options['compiler'] ) ) {
             	$plugin_options['REDUX_COMPILER'] = time();


### PR DESCRIPTION
This allows the hooked validation functions to actually change the options (I used it so that we could make an "only change options which the user physically entered data into" hook)
