### PR TITLE
Remove Forced Error reporting

### DIFF
--- a/tests/includes/install.php
+++ b/tests/includes/install.php
@@ -2,7 +2,6 @@
 /**
  * Installs Redux Framework for the purpose of the unit-tests
  */
-error_reporting( E_ALL & ~E_DEPRECATED & ~E_STRICT );
 
 echo "Welcome to the Redux Framework Test Suite" . PHP_EOL;
 echo "Version: 1.0" . PHP_EOL;


### PR DESCRIPTION
Although we could argue about whether error reporting should or shouldn't be set within a PHP File, the theme I submitted on Themeforest was rejected when bundled with Redux that includes error_reporting(). I had to manually remove it. I would love to keep up with the updates without doing merging myself all the time. So it would be nice if Redux just complied with Themeforest rules :)
