### PR TITLE
Image preview thumb not loading due to error

### DIFF
--- a/ReduxCore/inc/fields/media/field_media.js
+++ b/ReduxCore/inc/fields/media/field_media.js
@@ -52,7 +52,7 @@ function redux_add_file(event, selector) {
 		selector.find('.upload-width').val(attachment.attributes.width);
 		redux_change( jQuery(selector).find( '.upload-id' ) );
 		var thumbSrc = attachment.attributes.url;
-		if (typeof attachment.attributes.sizes.thumbnail.url !== 'undefined') {
+		if (typeof attachment.attributes.sizes.thumbnail !== 'undefined') {
 			thumbSrc = attachment.attributes.sizes.thumbnail.url;
 		} else {
 			var height = attachment.attributes.height;


### PR DESCRIPTION
Image preview thumb not loading due to error:
Uncaught TypeError: Cannot read property 'url' of undefined field_media.js?ver=1384354380:55
