### PR TITLE
Added check to render hidden fields only if top, left, bottom or right is set to true

### DIFF
--- a/ReduxCore/inc/fields/spacing/field_spacing.php
+++ b/ReduxCore/inc/fields/spacing/field_spacing.php
@@ -123,10 +123,21 @@ class ReduxFramework_spacing extends ReduxFramework{
 			echo '<div class="field-spacing-input input-prepend"><span class="add-on"><i class="el-icon-fullscreen icon-large"></i></span><input type="text" class="redux-spacing-all redux-spacing-input mini'.$this->field['class'].'" placeholder="'.__('All','redux-framework').'" rel="'.$this->field['id'].'-all" value="'.$this->value['top'].'"></div>';
 		}
 
-		echo '<input type="hidden" class="redux-spacing-value" id="'.$this->field['id'].'-top" name="'.$this->args['opt_name'].'['.$this->field['id'].']['.$this->field['mode'].'top]" value="'.$this->value['top'].(!empty($this->value['top']) ? $this->value['units'] : '').'">';
-		echo '<input type="hidden" class="redux-spacing-value" id="'.$this->field['id'].'-right" name="'.$this->args['opt_name'].'['.$this->field['id'].']['.$this->field['mode'].'right]" value="'.$this->value['right'].(!empty($this->value['right']) ? $this->value['units'] : '').'">';
-		echo '<input type="hidden" class="redux-spacing-value" id="'.$this->field['id'].'-bottom" name="'.$this->args['opt_name'].'['.$this->field['id'].']['.$this->field['mode'].'bottom]" value="'.$this->value['bottom'].(!empty($this->value['bottom']) ? $this->value['units'] : '').'">';
-		echo '<input type="hidden" class="redux-spacing-value" id="'.$this->field['id'].'-left" name="'.$this->args['opt_name'].'['.$this->field['id'].']['.$this->field['mode'].'left]" value="'.$this->value['left'].(!empty($this->value['left']) ? $this->value['units'] : '').'">';
+		if ($this->field['top'] === true):
+			echo '<input type="hidden" class="redux-spacing-value" id="'.$this->field['id'].'-top" name="'.$this->args['opt_name'].'['.$this->field['id'].']['.$this->field['mode'].'top]" value="'.$this->value['top'].(!empty($this->value['top']) ? $this->value['units'] : '').'">';
+		endif;
+
+		if ($this->field['right'] === true):
+			echo '<input type="hidden" class="redux-spacing-value" id="'.$this->field['id'].'-right" name="'.$this->args['opt_name'].'['.$this->field['id'].']['.$this->field['mode'].'right]" value="'.$this->value['right'].(!empty($this->value['right']) ? $this->value['units'] : '').'">';
+		endif;
+
+		if ($this->field['bottom'] === true):
+			echo '<input type="hidden" class="redux-spacing-value" id="'.$this->field['id'].'-bottom" name="'.$this->args['opt_name'].'['.$this->field['id'].']['.$this->field['mode'].'bottom]" value="'.$this->value['bottom'].(!empty($this->value['bottom']) ? $this->value['units'] : '').'">';
+		endif;
+
+		if ($this->field['left'] === true):
+			echo '<input type="hidden" class="redux-spacing-value" id="'.$this->field['id'].'-left" name="'.$this->args['opt_name'].'['.$this->field['id'].']['.$this->field['mode'].'left]" value="'.$this->value['left'].(!empty($this->value['left']) ? $this->value['units'] : '').'">';
+		endif;
 
 		if ( !isset( $this->field['all'] ) || $this->field['all'] !== true ) :
 			/**


### PR DESCRIPTION
Even if top, set, bottom or left is set to false for spacing field, the CSS is rendered for them equaling to 0px. This is because of the hidden fields which are rendered even if one of the field is set to false in settings array. I have added a check to stop hidden fields from rendered if they are set to false.
