### PR TITLE
Change css render name

### DIFF
--- a/ReduxCore/framework.php
+++ b/ReduxCore/framework.php
@@ -976,7 +976,7 @@ if( !class_exists( 'ReduxFramework' ) ) {
                 }
             }
             if ( !empty( $this->outputCSS ) && $this->args['output_tag'] == true ) {
-                echo '<style type="text/css" class="redux-output">'.$this->outputCSS.'</style>';  
+                echo '<style type="text/css" class="options-output">'.$this->outputCSS.'</style>';  
             }
         }        
 


### PR DESCRIPTION
Wordpress sites suck in being targetted for exploits attacks. The less bots can learn from the source, the less vulnerable the site becomes. So removed the redux-output to options-output. Might need to remove all class references..  but still nobody should know what the system is running.
