### PR TITLE
Fixes select_image visibility issue when no default available

### DIFF
--- a/ReduxCore/inc/fields/select_image/field_select_image.js
+++ b/ReduxCore/inc/fields/select_image/field_select_image.js
@@ -8,7 +8,7 @@
 			});
 		} else {
 			preview.attr('src', $(this).val());
-			preview.fadeIn();
+			preview.fadeIn().css('visibility', 'visible');
 		}
 	});
 


### PR DESCRIPTION
Initially, the select_image preview has a visibility:hidden style. If
the select_image doesn’t have a default value, changing the selected
value will not cause this to be changed resulting in a blank area where
the image should be shown.
