### PR TITLE
field_ace_editor.js dependency

### DIFF
--- a/ReduxCore/inc/fields/ace_editor/field_ace_editor.php
+++ b/ReduxCore/inc/fields/ace_editor/field_ace_editor.php
@@ -91,7 +91,7 @@ class ReduxFramework_ace_editor extends ReduxFramework{
             wp_enqueue_script(
                 'redux-field-ace-editor-js', 
                 ReduxFramework::$_url . 'inc/fields/ace_editor/field_ace_editor.js', 
-                array( 'jquery' ),
+                array( 'jquery', 'ace-editor-js' ),
                 time(),
                 true
             );


### PR DESCRIPTION
ensure ace.js on wp_enqueue_script

I just had a case when ace.js was loaded after field_ace_editor.js and the script failed.
