### PR TITLE
fields should have script enqueueing methods called always, not just when in dev mode?

### DIFF
--- a/ReduxCore/framework.php
+++ b/ReduxCore/framework.php
@@ -1315,8 +1315,8 @@ if( !class_exists( 'ReduxFramework' ) ) {
                                         $this->options[$field['id']] = "";
                                     }
                                     $theField = new $field_class( $field, $this->options[$field['id']], $this );
-                                    
-                                    if ( !wp_script_is( 'redux-field-'.$field['type'].'-js', 'enqueued' ) && class_exists($field_class) && $this->args['dev_mode'] === true && method_exists( $field_class, 'enqueue' ) ) {
+
+                                    if ( !wp_script_is( 'redux-field-'.$field['type'].'-js', 'enqueued' ) && class_exists($field_class) && method_exists( $field_class, 'enqueue' ) ) {
                                         /** @noinspection PhpUndefinedMethodInspection */
                                         //echo "DOVY";
                                         $theField->enqueue();    


### PR DESCRIPTION
I am not entirely sure about this one, I could just be missing something. But I feel as though it should work this way to avoid breaking backwards compatibility with custom field classes that have their own scripts registered.
