### PR TITLE
Fixing border field bug

### DIFF
--- a/ReduxCore/inc/fields/dimensions/field_dimensions.php
+++ b/ReduxCore/inc/fields/dimensions/field_dimensions.php
@@ -249,7 +249,7 @@ class ReduxFramework_dimensions extends ReduxFramework {
             // nothing to do here, but I'm leaving the construct just in case I have to debug this again.
         }
 
-        $units = isset( $this->field['units'] ) ? $this->field['units'] : "";
+        $units = isset( $this->value['units'] ) ? $this->value['units'] : "";
 
 
         $cleanValue = array(


### PR DESCRIPTION
If all => true is used for border config right now, it will throw an error right now that $value doesn't exist. This fixes it.
