### PR TITLE
Generate correct css for link_color field when compiler is true

### DIFF
--- a/ReduxCore/inc/fields/link_color/field_link_color.php
+++ b/ReduxCore/inc/fields/link_color/field_link_color.php
@@ -166,7 +166,11 @@ if( !class_exists( 'ReduxFramework_link_color' ) ) {
                         if (is_numeric($key)) {
                             $styleString .= implode(",", $this->field['compiler']) . "{" . $value . '}';
                         } else {
-                            $styleString .= implode(":".$key.",", $this->field['compiler']) . "{" . $value . '}';
+                            if (count($key) == 1) {
+                                $styleString .= $this->field['compiler'][0].":".$key . "{" . $value . '}';
+                            } else {
+                                $styleString .= implode(":".$key.",", $this->field['compiler']) . "{" . $value . '}';    
+                            }
                         }
                     }
                     $this->parent->compilerCSS .= $styleString;  


### PR DESCRIPTION
The css was not generated for :hover and :active.
