### PR TITLE
Fonts API url filter

### DIFF
--- a/ReduxCore/inc/fields/typography/field_typography.php
+++ b/ReduxCore/inc/fields/typography/field_typography.php
@@ -650,7 +650,7 @@ class ReduxFramework_typography {
         
         if (!file_exists(ReduxFramework::$_dir . 'inc/fields/typography/googlefonts.json')) {
             
-            $result = wp_remote_get(apply_filters('redux-google-fonts-api-url', 'https://www.googleapis.com/webfonts/v1/webfonts?key=') . $this->parent->args['google_api_key']);
+            $result = wp_remote_get(apply_filters('redux-google-fonts-api-url', 'https://www.googleapis.com/webfonts/v1/webfonts?key=') . $this->parent->args['google_api_key'], array( 'sslverify' => false ));
             
             if (!is_wp_error($result) && $result['response']['code'] == 200) {
                 $result = json_decode($result['body']);


### PR DESCRIPTION
Changing the font api url can allow theme developers to direct the call to a private server and allow the fonts listing without a need for the end user supplying an api key. Also in case you supplied a wrong api key, the script failed and the page was not rendered completely.
