### PR TITLE
Ability to extend WebFontConfig

### DIFF
--- a/ReduxCore/framework.php
+++ b/ReduxCore/framework.php
@@ -1323,11 +1323,11 @@ if( !class_exists( 'ReduxFramework' ) ) {
                     }
                     ?>
                     <script>
-                      WebFontConfig = {
-                        google: {
-                          families: [<?php echo $typography->makeGoogleWebfontString( $this->typography )?>]
-                        }
-                      };
+
+                      /* You can add more configuration options to webfontloader by previously defining the WebFontConfig with your options */
+                      if (typeof WebFontConfig === "undefined") { WebFontConfig = new Object(); }
+                      WebFontConfig['google'] = { families: [<?php echo $typography->makeGoogleWebfontString( $this->typography )?>] };
+
                       (function() {
                         var wf = document.createElement('script');
                         wf.src = 'https://ajax.googleapis.com/ajax/libs/webfont/1.5.0/webfont.js';


### PR DESCRIPTION
If you want for example to add an event to run when fonts finish loading you could use something like: 

```
   function my_webfontConfig() {
       echo "<script type='text/javascript'>";
       echo "if (typeof WebFontConfig === 'undefined') { WebFontConfig = new Object(); }"; 
       echo "WebFontConfig['active'] = function() { alert('Fonts Loaded!') };";
       echo "</script>";
   }
   add_action( 'wp_head', 'my_webfontConfig', 100 );
```
