### PR TITLE
Sorter field: Merge arrays without modifying indexes

### DIFF
--- a/ReduxCore/inc/fields/sorter/field_sorter.php
+++ b/ReduxCore/inc/fields/sorter/field_sorter.php
@@ -64,14 +64,14 @@ class ReduxFramework_sorter {
 	    $temp2 = array(); // holds saved blocks
 
 		foreach($all_blocks as $blocks) {
-		    $temp = array_merge($temp, $blocks);
+		    $temp = $temp + $blocks;
 		}
 
 	    $sortlists = $this->value;
 
 	    if ( is_array( $sortlists ) ) {
 		    foreach( $sortlists as $sortlist ) {
-				$temp2 = array_merge($temp2, $sortlist);
+				$temp2 = $temp2 + $sortlist;
 		    }
 
 		    // now let's compare if we have anything missing
@@ -115,7 +115,7 @@ class ReduxFramework_sorter {
 					    echo '<h3>'.$group.'</h3>';
 
                         if (!isset($sortlist['placebo'])){
-                            array_unshift($sortlist, array( "placebo" => "placebo" ));
+                            $sortlist = array( "placebo" => "placebo" ) + $sortlist;
                         }
 
 					    foreach ($sortlist as $key => $list) {


### PR DESCRIPTION
When using the sorter field with dynamic content where ID's are used as array keys there is a bug when using `array_merge` and `array_unshift` due to the fact they modify the array index.

This fixes the issues in #1102.

Example option config:

```
array(
    'id'        => 'opt-homepage-layout',
    'type'      => 'sorter',
    'title'     => 'Layout Manager Advanced',
    'subtitle'  => 'You can add multiple drop areas or columns.',
    'compiler'  => 'true',
    'data'      => array('disabled'=>'posts'),
    'args'      => array('disabled'=>array('post_type'=>'home', 'posts_per_page'=>-1)),
    'options'   =>  array(
        'enabled'   => array(),
        'disabled'  => array(),
    ),
),
```
