### PR TITLE
removed leftover debug code

### DIFF
--- a/ReduxCore/inc/fields/spacing/field_spacing.php
+++ b/ReduxCore/inc/fields/spacing/field_spacing.php
@@ -270,7 +270,6 @@ if (!class_exists('ReduxFramework_spacing')) {
 
             $mode = ( $this->field['mode'] != "absolute" ) ? $this->field['mode'] : "";
             $units = isset($this->value['units']) ? $this->value['units'] : "";
-            echo 'units: ' . $units;
             $style = '';
 
             if (!empty($mode)) {


### PR DESCRIPTION
fixed 'units: units: units: units:' in the header after 3.1.9.12
