### PR TITLE
Add minimum results for search bar to appear

### DIFF
--- a/ReduxCore/inc/fields/select/field_select.js
+++ b/ReduxCore/inc/fields/select/field_select.js
@@ -15,7 +15,8 @@
             var default_params = {
                 width:          'resolve',
                 triggerChange:  true,
-                allowClear:     true
+                allowClear:     true,
+                minimumResultsForSearch: 10
             };
 
             if ($(this).siblings('.select2_params').size() > 0) {


### PR DESCRIPTION
No need to have a search bar for less than 10 results. Saves some screen space, and makes more sense.
