### PR TITLE
Update color-picker.js

### DIFF
--- a/ReduxCore/assets/js/color-picker/color-picker.js
+++ b/ReduxCore/assets/js/color-picker/color-picker.js
@@ -18,7 +18,7 @@
         $('.redux-color-init').wpColorPicker({
             change: function(u) {
                 redux_change($(this));
-                $('#' + u.target.id + '-transparency').removeAttr('checked');
+                $('#' + u.target.getAttribute('data-id') + '-transparency').removeAttr('checked');
             },
             clear: function() {
                 redux_change($(this).parent().find('.redux-color-init'));


### PR DESCRIPTION
Get the data-id attr, not the actual id. The transparent option turns off if the user chooses a color while it is checked.

Issue: #1272
