### PR TITLE
Update field_sortable.php

### DIFF
--- a/ReduxCore/inc/fields/sortable/field_sortable.php
+++ b/ReduxCore/inc/fields/sortable/field_sortable.php
@@ -112,7 +112,7 @@
                         if ( $this->field['mode'] != "checkbox" ) {
                             echo "<br />";
                         }
-                        echo '<label for="' . $this->field['id'] . '[' . $k . ']"><strong>' . $options[ $k ] . '</strong></label>';
+                        echo '<label for="' . $this->field['id'] . '[' . $k . ']"><strong>' . $k . '</strong></label>';
                     }
                     if ( $this->field['mode'] == "checkbox" ) {
                         echo '</div>';


### PR DESCRIPTION
The label should stay the same so people know what that field is for. Right now it just displays the input from the textfield (redundant).

Ideally might be best to have an array for each option

'key' => array( 'input', 'label' ) - or something of the sort. I'll think about it.

In my case I use this for social options, so under each field the label should read "Twitter, Facebook, Dribble...etc" and the field value should have a sample URL.
