### PR TITLE
Update framework.php

### DIFF
--- a/ReduxCore/framework.php
+++ b/ReduxCore/framework.php
@@ -542,11 +542,6 @@
                 return self::$instance;
             } // get_instance()
 
-            public static function _instance() {
-                self::$_instance = $this;
-                return self::$_instance;
-            }
-            
             public function _tracking() {
                 include_once( dirname( __FILE__ ) . '/inc/tracking.php' );
                 $tracking = Redux_Tracking::get_instance();


### PR DESCRIPTION
This is static context and `$this` can't be accessed. It is an error.
If there is a need for a static function to get the instance of the framework, `get_instance()` can be safely made static
