### PR TITLE
Enable page_priority for submenu

### DIFF
--- a/ReduxCore/framework.php
+++ b/ReduxCore/framework.php
@@ -391,7 +391,13 @@
                     //add_action( 'init', array( &$this, '_set_default_options' ), 101 );
 
                     // Options page
-                    add_action( 'admin_menu', array( $this, '_options_page' ) );
+                    if ( 'submenu' == $this->args['menu_type'] && $this->args['page_priority'] ) {
+                        $priority = $this->args['page_priority'];
+                        add_action( 'admin_menu', array( $this, '_options_page' ), $priority );
+                    }
+                    else {
+                        add_action( 'admin_menu', array( $this, '_options_page' ) );
+                    }
 
                     // Add a network menu
                     if ( $this->args['database'] == "network" && $this->args['network_admin'] ) {


### PR DESCRIPTION
add_submenu_page does not have position / priority parameter.
page_priority param for submenu needs to be attached to admin_menu
action...
