### PR TITLE
remove debug code

### DIFF
--- a/ReduxCore/inc/class.redux_filesystem.php
+++ b/ReduxCore/inc/class.redux_filesystem.php
@@ -55,7 +55,6 @@ if (!class_exists('Redux_Filesystem')){
             
             // Do unique stuff
             if ($action == 'mkdir') {
-                echo $file;
                 $res = $wp_filesystem->$action($file, 0755 );
             } elseif ($action == 'copy') {
                 echo $wp_filesystem->copy($file, $destination, $overwrite, 0644 );


### PR DESCRIPTION
This debug code appears only when the wp-content/redux folder isn't created(usually on theme activation).

I would suggest to put in the code style guideline a new rule: "Always use var_dump/var_export on debugging because an echo is really hard to track when is forgotten".(Just saying because I lost 2 hours debugging line by line to find that echo :) )

Cheers
