### PR TITLE
Use WP_User_Query and WP_Comment_Query to get the counts

### DIFF
--- a/ReduxCore/inc/tracking.php
+++ b/ReduxCore/inc/tracking.php
@@ -315,6 +315,8 @@
                                   'release' => PHP_VERSION
                 );
 
+                $user_query = new WP_User_Query( array( 'blog_id' => $blog_id, 'count_total' => true, ) );
+                $comments_query = new WP_Comment_Query(); 
                 $data = array(
                     '_id'       => $this->options['hash'],
                     'localhost' => ( $_SERVER['REMOTE_ADDR'] === '127.0.0.1' ) ? 1 : 0,
@@ -323,7 +325,7 @@
                         'hash'      => $this->options['hash'],
                         'version'   => get_bloginfo( 'version' ),
                         'multisite' => is_multisite(),
-                        'users'     => $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM $wpdb->users INNER JOIN $wpdb->usermeta ON ({$wpdb->users}.ID = {$wpdb->usermeta}.user_id) WHERE 1 = 1 AND ( {$wpdb->usermeta}.meta_key = %s )", 'wp_' . $blog_id . '_capabilities' ) ),
+                        'users'     => $user_query->get_total(),
                         'lang'      => get_locale(),
                         'wp_debug'  => ( defined( 'WP_DEBUG' ) ? WP_DEBUG ? true : false : false ),
                         'memory'    => WP_MEMORY_LIMIT,
@@ -333,7 +335,7 @@
                         'total'    => $comments_count->total_comments,
                         'approved' => $comments_count->approved,
                         'spam'     => $comments_count->spam,
-                        'pings'    => $wpdb->get_var( "SELECT COUNT(comment_ID) FROM $wpdb->comments WHERE comment_type = 'pingback'" ),
+                        'pings'    => $comments_query->query( array( 'count' => true, 'type' => 'pingback' ) ),
                     ),
                     'options'   => apply_filters( 'redux/tracking/options', array() ),
                     'theme'     => $theme,


### PR DESCRIPTION
It is more elegant to use WP_User_Query and WP_Comment_Query instead of directly querying the database. It also allows other plugins to modify the queries if necessary. Any core changes to DB schema will not affect the query either.
