### PR TITLE
google fonts link arg

### DIFF
--- a/ReduxCore/framework.php
+++ b/ReduxCore/framework.php
@@ -395,6 +395,7 @@
                     // Save defaults to the DB on it if empty
                     'footer_credit'      => '',
                     'async_typography'   => false,
+                    'google_fonts_link'  => true,
                     'class'              => '',
                     // Class that gets appended to all redux-containers
                     'admin_bar'          => true,
@@ -1415,7 +1416,7 @@
                             })();
                         </script>
                     <?php
-                    } else {
+                    } elseif ( $this->args['google_fonts_link'] ) {
                         $protocol = ( ! empty( $_SERVER['HTTPS'] ) && $_SERVER['HTTPS'] !== 'off' || $_SERVER['SERVER_PORT'] == 443 ) ? "https:" : "http:";
 
                         //echo '<link rel="stylesheet" id="options-google-fonts" title="" href="'.$protocol.$typography->makeGoogleWebfontLink( $this->typography ).'&amp;v='.$version.'" type="text/css" media="all" />';

--- a/sample/sample-config.php
+++ b/sample/sample-config.php
@@ -1545,6 +1545,7 @@ if (!class_exists('Redux_Framework_sample_config')) {
                 'google_api_key' => '', // Must be defined to add google fonts to the typography module
                 
                 'async_typography'  => true,                    // Use a asynchronous font on the front end or font string
+                'google_fonts_link' => true,                    // Disable this in case you want to create your own google fonts loader
                 'admin_bar'         => true,                    // Show the panel pages on the admin bar
                 'global_variable'   => '',                      // Set a different name for your global variable other than the opt_name
                 'dev_mode'          => true,                    // Show the time the page took to load, etc


### PR DESCRIPTION
I saw some recent activity in this area and its good stuff, but there are some rare cases when redux should let the developer to play with that google fonts api. For example I'm triggering some custom events(for some text animations) on fonts load and my WebFontConfig is slightly different.

We should be able do enable/disable both the async loading and the static one.

Cheers!
