### PR TITLE
Added .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,26 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+
+[*.php]
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.less]
+indent_size = 4
+
+[*.scss]
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+
+[package.json]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Added .editorconfig to have a standard codingstyle with all editors.
Currenctly you only have an XML for PHPStorm, but a lot of people use Sublime Text 2, Atom or another one.
