### PR TITLE
Add support for a "output_hook" argument

### DIFF
--- a/ReduxCore/framework.php
+++ b/ReduxCore/framework.php
@@ -369,7 +369,7 @@
                     add_action( 'wp_head', array( &$this, '_output_css' ), 150 );
 
                     // Enqueue dynamic CSS and Google fonts
-                    add_action( 'wp_enqueue_scripts', array( &$this, '_enqueue_output' ), 150 );
+                    add_action( $this->args['output_hook'], array( &$this, '_enqueue_output' ), 150 );
 
                     add_action( 'wp_print_scripts', array( $this, 'vc_fixes' ), 100 );
                     add_action( 'admin_enqueue_scripts', array( $this, 'vc_fixes' ), 100 );
@@ -455,6 +455,8 @@
                     // Changes global variable from $GLOBALS['YOUR_OPT_NAME'] to whatever you set here. false disables the global variable
                     'output'                    => true,
                     // Dynamically generate CSS
+                    'output_hook'               => 'wp_enqueue_scripts',
+                    // Hook where dynamically generated CSS will be enqueued
                     'compiler'                  => true,
                     // Initiate the compiler hook
                     'output_tag'                => true,


### PR DESCRIPTION
As mentioned in #1585, I needed an option to enqueue the styles and the Google Fonts tag at the login/register pages.

With this argument in place, you can simply override the hook that is used to enqueue the styles. You probably don't ever have to make use of this argument, except you want to enqueue the styles on login or admin pages.

Within your Redux configuration setup, you can now simply add `'output_hook' => 'login_enqueue_scripts',` to load the styles there.
