### PR TITLE
fix ace editor params encoding

### DIFF
--- a/ReduxCore/inc/fields/ace_editor/field_ace_editor.php
+++ b/ReduxCore/inc/fields/ace_editor/field_ace_editor.php
@@ -75,7 +75,7 @@
                 ?>
                 <div class="ace-wrapper">
                     <input type="hidden" class="localize_data"
-                           value="<?php echo htmlspecialchars( json_encode( $params, true ) ); ?>"/>
+                           value="<?php echo htmlspecialchars( json_encode( $params ) ); ?>"/>
                     <textarea name="<?php echo $this->field['name'] . $this->field['name_suffix']; ?>"
                               id="<?php echo $this->field['id']; ?>-textarea"
                               class="ace-editor hide <?php echo $this->field['class']; ?>"


### PR DESCRIPTION
json_encode second param is not boolean type, it supposed to be a string like "JSON_UNESCAPED_UNICODE" or nothing (probably confused with json_decode function which has the second param a boolean type).

I just found out that on php 5.2.17 this cause the function to return NULL an the ace editor will fail in javascript.
