### PR TITLE
Added support for better admin bar with external links

### DIFF
--- a/ReduxCore/framework.php
+++ b/ReduxCore/framework.php
@@ -1403,6 +1403,26 @@
                             $wp_admin_bar->add_node( $subnodeargs );
                         }
                     }
+
+                    // Let's deal with external links
+                    if ( isset( $this->args['admin_bar_links'] ) ) {
+
+                        // Group for Main Root Menu (External Group)
+                        $wp_admin_bar->add_node( array( 'id' => $this->args["page_slug"] . '-external', 'parent' => $this->args["page_slug"], 'group' => true, 'meta' => array( 'class' => 'ab-sub-secondary' ) ) );
+
+                        // Add Child Menus to External Group Menu
+                        foreach ( $this->args['admin_bar_links'] as $link ) {
+                            $externalnodeargs = array(
+                                'id'     => $link['id'],
+                                'title'  => $link['title'],
+                                'parent' => $this->args["page_slug"] . '-external',
+                                'href'   => $link['href'],
+                                'meta'   => array( 'target' => '_blank' )
+                            );
+
+                            $wp_admin_bar->add_node( $externalnodeargs );
+                        }
+                    }
                 } else {
                     $nodeargs = array(
                         'id'    => $this->args["page_slug"],


### PR DESCRIPTION
**Features:**
- Set the `admin_bar_priority` else default `999` will be applied.
- Don't culprit with default `admin_bar_icon`. If they want they can apply via `$args`. Condition patched.
- Added support for `$this->args['admin_bar_links'][]` so fixes #1645 

**TODO:**
@dovy links are not clickable in framework page but when you goto default wp pages and browser those links then it's working. I couldn't understand why the framework pages is not loading link.
