### PR TITLE
Addition to Admin Bar

### DIFF
--- a/ReduxCore/framework.php
+++ b/ReduxCore/framework.php
@@ -1381,6 +1381,7 @@
                     foreach ( $menu as $menu_item ) {
                         if ( isset( $menu_item[2] ) && $menu_item[2] === $this->args["page_slug"] ) {
 
+                            // Fetch the title
                             $title = empty( $this->args['admin_bar_icon'] ) ? $menu_item[0] : '<span class="ab-icon ' . $this->args['admin_bar_icon'] . '"></span>' . $menu_item[0];
 
                             $nodeargs = array(
@@ -1436,7 +1437,7 @@
                         }
                     }
                 } else {
-
+                    // Fetch the title
                     $title = empty( $this->args['admin_bar_icon'] ) ? $this->args['menu_title'] : '<span class="ab-icon ' . $this->args['admin_bar_icon'] . '"></span>' . $this->args['menu_title'];
 
                     $nodeargs = array(


### PR DESCRIPTION
Condition patch to hide generic icon in frontend if the users don't implement `admin_bar_icon` args. Final fix for #1653 
