### PR TITLE
Sanitize some hard coded URLs with esc_url() function

### DIFF
--- a/ReduxCore/inc/class.redux_themecheck.php
+++ b/ReduxCore/inc/class.redux_themecheck.php
@@ -58,7 +58,7 @@
                             ?>
                             <div class="updated">
                             <p><?php
-                                    echo sprintf( __( 'The theme you are testing has %s embedded. We invite you to read the %sTheme-Check Documentation%s to understand some warnings you will see because of Redux.', 'redux-framework' ), '<a href="' . esc_url( 'http://reduxframework.com' ) . '" target="_blank">Redux Framework</a>', '<a href="' . esc_url( 'http://docs.reduxframework.com/core/theme-check/' ) . '">', '</a>' );
+                                    echo sprintf( __( 'The theme you are testing has %s embedded. We invite you to read the %sTheme-Check Documentation%s to understand some warnings you will see because of Redux.', 'redux-framework' ), '<a href="' . 'http://reduxframework.com' . '" target="_blank">Redux Framework</a>', '<a href="' . 'http://docs.reduxframework.com/core/theme-check/' . '">', '</a>' );
                                 ?>
                             </div><?php
                         }

--- a/class.redux-plugin.php
+++ b/class.redux-plugin.php
@@ -404,10 +404,10 @@
                 if ( strpos( $file, 'redux-framework.php' ) !== false && is_plugin_active( $file ) ) {
 
                     $new_links = array(
-                        '<a href="' . esc_url( 'https://github.com/ReduxFramework/redux-framework' ) . '" target="_blank">' . __( 'Repo', 'redux-framework' ) . '</a>',
-                        '<a href="' . esc_url( 'http://generate.reduxframework.com/' ) . '" target="_blank">' . __( 'Generator', 'redux-framework' ) . '</a>',
-                        '<a href="' . esc_url( 'https://github.com/ReduxFramework/redux-framework/issues/' ) . '" target="_blank">' . __( 'Issues', 'redux-framework' ) . '</a>',
-                        '<a href="' . esc_url( 'http://docs.reduxframework.com/' ) . '" target="_blank">' . __( 'Documentation', 'redux-framework' ) . '</a>',
+                        '<a href="' . 'https://github.com/ReduxFramework/redux-framework' . '" target="_blank">' . __( 'Repo', 'redux-framework' ) . '</a>',
+                        '<a href="' . 'http://generate.reduxframework.com/' . '" target="_blank">' . __( 'Generator', 'redux-framework' ) . '</a>',
+                        '<a href="' . 'https://github.com/ReduxFramework/redux-framework/issues/' . '" target="_blank">' . __( 'Issues', 'redux-framework' ) . '</a>',
+                        '<a href="' . 'http://docs.reduxframework.com/' . '" target="_blank">' . __( 'Documentation', 'redux-framework' ) . '</a>',
                     );
 
                     if ( ( is_multisite() && $this->plugin_network_activated ) || ! is_network_admin() || ! is_multisite() ) {


### PR DESCRIPTION
Sanitizing hard coded URLs with esc_url() function removes message `INFO: Possible hard-coded links were found in the file class` from Theme Check. Having this message is no problem at all, but not having is better than that.
