### PR TITLE
Fixed PHP Warnings: Illegal offset string

### DIFF
--- a/ReduxCore/framework.php
+++ b/ReduxCore/framework.php
@@ -3054,7 +3054,11 @@
                 foreach ( $sections as $k => $section ) {
                     if ( isset( $section['fields'] ) ) {
                         foreach ( $section['fields'] as $fkey => $field ) {
-                            $field['section_id'] = $k;
+
+                            if( is_array( $field ) ) {
+                               $field['section_id'] = $k; 
+                            }
+                            
 
                             if ( isset( $field['type'] ) && ( $field['type'] == 'checkbox' || $field['type'] == 'checkbox_hide_below' || $field['type'] == 'checkbox_hide_all' ) ) {
                                 if ( ! isset( $plugin_options[ $field['id'] ] ) ) {
@@ -3078,7 +3082,7 @@
 
                             // Check for empty id value
 
-                            if ( ! isset( $plugin_options[ $field['id'] ] ) || ( isset( $plugin_options[ $field['id'] ] ) && $plugin_options[ $field['id'] ] == '' ) ) {
+                            if ( ! isset( $field['id'] ) || ! isset( $plugin_options[ $field['id'] ] ) || ( isset( $plugin_options[ $field['id'] ] ) && $plugin_options[ $field['id'] ] == '' ) ) {
 
                                 // If we are looking for an empty value, in the case of 'not_empty'
                                 // then we need to keep processing.


### PR DESCRIPTION
Hi,

had a client with this issues:

Warning: Illegal string offset 'SECTION_ID' in
/plugins/redux-framework/ReduxCore/framework.php on line 3057
Warning: Illegal offset string 'id' in
/plugins/redux-framework/ReduxCore/framework.php on line 3081
Header already sent...
1. Redux Version: 3.3.9.4 (as plugin)
2. Wordpress: 4.0.1
3. Dev Mode: No

This is my quick fix for the issue.

Best,
Christian
