### PR TITLE
verFromGit: Stable releases only, Git tags

### DIFF
--- a/ReduxCore/inc/class.redux_functions.php
+++ b/ReduxCore/inc/class.redux_functions.php
@@ -94,57 +94,29 @@ if ( ! class_exists( 'Redux_Functions' ) ) {
         }
 
         /**
-         * verFromGit - Retrives latest Redux version from GIT
+         * verFromGit - Retrieves latest stable Redux release from GitHub
          *
          * @since       3.2.0
          * @access      private
          * @return      string $ver
          */
         private static function verFromGit() {
-            // Get the raw framework.php from github
+            // Get the latest tagged release from GitHub
             $gitpage = wp_remote_get(
-                'https://raw.github.com/ReduxFramework/redux-framework/master/ReduxCore/framework.php', array(
+                'https://api.github.com/repos/reduxframework/redux-framework/releases/latest', array(
                     'headers'   => array(
-                        'Accept-Encoding' => ''
+                        'Accept' => 'application/vnd.github.v3+json'
                     ),
                     'sslverify' => true,
                     'timeout'   => 300
                 ) );
 
-            // Is the response code the corect one?
+            // Ensure we got a valid response
             if ( ! is_wp_error( $gitpage ) ) {
                 if ( isset( $gitpage['body'] ) ) {
-                    // Get the page text.
-                    $body = $gitpage['body'];
-
-                    // Find version line in framework.php
-                    $needle = 'public static $_version =';
-                    $pos    = strpos( $body, $needle );
-
-                    // If it's there, continue.  We don't want errors if $pos = 0.
-                    if ( $pos > 0 ) {
-
-                        // Look for the semi-colon at the end of the version line
-                        $semi = strpos( $body, ";", $pos );
-
-                        // Error avoidance.  If the semi-colon is there, continue.
-                        if ( $semi > 0 ) {
-
-                            // Extract the version line
-                            $text = substr( $body, $pos, ( $semi - $pos ) );
-
-                            // Find the first quote around the veersion number.
-                            $quote = strpos( $body, "'", $pos );
-
-                            // Extract the version number
-                            $ver = substr( $body, $quote, ( $semi - $quote ) );
-
-                            // Strip off quotes.
-                            $ver = str_replace( "'", '', $ver );
-
-                            return $ver;
-                        }
-                    }
+                    // Decode the response and get version from the tag name.
+                    $body = json_decode( $gitpage['body'], true );
+                    return $body['tag_name'];
                 }
             }
         }


### PR DESCRIPTION
## Scenario
If my `composer.json` contains `"wpackagist-plugin/redux-framework": "3.4.1",` then I receive the following message in my WordPress admin:

![redux-new-version](https://cloud.githubusercontent.com/assets/3905798/6277219/d203bb3e-b85a-11e4-8651-0c07cb54842a.png)

Sure enough, at this very second the [master branch `framework.php` file](https://github.com/reduxframework/redux-framework/blob/658d8361acfe15a22fe573b9917895638c20bf85/ReduxCore/framework.php) shows version `3.4.3.2`. ...But this release doesn't exist yet. At the very least, [it certainly isn't tagged](https://github.com/reduxframework/redux-framework/releases). I can't upgrade to this version in the WordPress admin, and I can't grab this version with composer unless I track `dev-master` or a specific commit. I'd rather not do this, and I don't think I'm alone in that regard.

Additionally, if you look in these [three](https://github.com/reduxframework/redux-framework/releases) [different](https://packagist.org/packages/redux-framework/redux-framework) [places](http://wpackagist.org/?q=redux-framework&type=any), you'll see that the `3.4.3.2` version isn't listed at all.

## Solution
 1. Don't parse the source code when an API will do (implemented).
 2. Could you please [tag all stable versions](https://github.com/reduxframework/redux-framework/blob/master/CHANGELOG.md) so developers can easily track them? :smile: