### PR TITLE
Update field_sortable.php

### DIFF
--- a/ReduxCore/inc/fields/sortable/field_sortable.php
+++ b/ReduxCore/inc/fields/sortable/field_sortable.php
@@ -117,7 +117,7 @@ if ( ! class_exists( 'ReduxFramework_sortable' ) ) {
 
                 if ($this->field['mode'] != "checkbox") {
                     if ($use_labels) {
-                        echo '<label class="bugger" for="' . $this->field['id'] . '[' . $k . ']"><strong>' . $k . '</strong></label>';
+                        echo '<label class="bugger" for="' . $this->field['id'] . '[' . $k . ']"><strong>' . $nicename . '</strong></label>';
                         echo "<br />";
                     }
                 }
@@ -131,7 +131,7 @@ if ( ! class_exists( 'ReduxFramework_sortable' ) ) {
                         //echo "<br />";
                         //echo '<label for="' . $this->field['id'] . '[' . $k . ']"><strong>' . $k . '</strong></label>';
                     } else {
-                        echo '<label for="' . $this->field['id'] . '[' . $k . ']"><strong>' .  $k . '</strong></label>';
+                        echo '<label for="' . $this->field['id'] . '[' . $k . ']"><strong>' .  $nicename . '</strong></label>';
                     }
                 }
                 if ( $this->field['mode'] == "checkbox" ) {


### PR DESCRIPTION
Updated the lines 120 & 134 and replaced $k by $nicename to display the option's value - as the label of the text fields and checkboxes -  instead of the option's key.

On line 120, replaced 
<pre>echo '&lt;label class="bugger" for="' . $this->field['id'] . '[' . $k . ']"&gt;&lt;strong&gt;' . $k. '&lt;/strong&gt;&lt;/label&gt;';</pre>
by
<pre>echo '&lt;label class="bugger" for="' . $this->field['id'] . '[' . $k . ']"&gt;&lt;strong&gt;' . $nicename . '&lt;/strong&gt;&lt;/label&gt;';</pre>

On line 134, replaced 
<pre>echo '&lt;label for="' . $this->field['id'] . '[' . $k . ']"&gt;&lt;strong&gt;' .  $k. '&lt;/strong&gt;&lt;/label&gt;';</pre>
by
<pre>echo '&lt;label for="' . $this->field['id'] . '[' . $k . ']"&gt;&lt;strong&gt;' .  $nicename . '&lt;/strong&gt;&lt;/label&gt;';</pre>

Thank you