### PR TITLE
Fix #2221 Calling wp_enqueue_media() for background field

### DIFF
--- a/ReduxCore/inc/fields/background/field_background.php
+++ b/ReduxCore/inc/fields/background/field_background.php
@@ -348,6 +348,9 @@
              * @return      void
              */
             public function enqueue() {
+
+                wp_enqueue_media();
+                
                 wp_enqueue_style( 'select2-css' );
                 wp_enqueue_style( 'wp-color-picker' );
                 


### PR DESCRIPTION
Calling wp_enqueue_media() for background field to support media upload feature.