### PR TITLE
allow for including redux in non isolation unit testing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,3 +25,53 @@ The way in which we diagnose bugs or config difficulties is to attempt to recrea
 What we do NOT do is debug your code.  We support the Redux code and the way in which the config is put together.  Any other issue pertaining to your project is your own, or we might be able to assist with premium support.
 
 - Team Redux
+
+## Running the tests
+
+The tests are built using [wordpress's make subversion repository](https://make.wordpress.org/core/handbook/automated-testing/)
+
+`/var/www/wordpress-develop` as the destination for the core test files.
+First download the wordress core tests repository, for these files.
+
+```bash
+cd /var/www
+svn co http://develop.svn.wordpress.org/trunk/ wordpress-develop
+```
+
+In the newly created `/var/www/wordpress-develop` directory rename
+`wp-tests-config-sample.php` to `wp-tests-config.php`. Now add your database
+details to the new file:
+```php
+// WARNING WARNING WARNING!
+// These tests will DROP ALL TABLES in the database with the prefix named below.
+// DO NOT use a production database or one that is shared with something else.
+
+define( 'DB_NAME', 'wordpress-tests' );
+define( 'DB_USER', 'root' );
+define( 'DB_PASSWORD', 'passowrd' );
+define( 'DB_HOST', 'localhost' );
+define( 'DB_CHARSET', 'utf8' );
+define( 'DB_COLLATE', '' );
+```
+ - <b>n.b.</b> you may need to create the database first.
+ - <b>n.b. n.b.</b> also note that the database used will be emptied on each run.
+
+Set the `WP_TESTS_DIR` environment variable so that the `redux-framework` test bootstrap file can find the wordpress core tests:
+```bash
+export WP_TESTS_DIR='/var/www/wordpress-develop/tests/phpunit/includes/'
+```
+
+You should now be able to run the `redux-framework` unit tests:
+```bash
+redux-framework$ phpunit
+Welcome to the TIVWP Test Suite
+Version: 1.0
+
+Tests folder: /var/www/wordpress-develop/tests/phpunit/includes/
+
+Installing...
+...
+Configuration read from
+redux-framework/phpunit.xml
+...
+```

--- a/ReduxCore/core/newsflash.php
+++ b/ReduxCore/core/newsflash.php
@@ -69,7 +69,7 @@
                         // if local and server data are same, then return
                         if (  strcmp ( $data, $cache_data ) == 0) {
                             // set new cookie for interval value
-                            setcookie( $this->cookie_id, time(), time() + (86400 * $this->interval), '/' );
+                            reduxCookie::setcookie( $this->cookie_id, time(), time() + (86400 * $this->interval), '/' );
                             
                             // bail out
                             return;
@@ -85,7 +85,7 @@
                     $filesystem->execute('put_contents', $this->notice_json, $params);
                     
                     // set cookie for three day expiry
-                    setcookie( $this->cookie_id, time(), time() + (86400 * $this->interval), '/' );
+                    reduxCookie::setCookie( $this->cookie_id, time(), time() + (86400 * $this->interval), '/' );
                     
                     // set unique key for dismiss meta key
                     update_option($this->cookie_id, time());

--- a/ReduxCore/framework.php
+++ b/ReduxCore/framework.php
@@ -52,6 +52,7 @@
         // General functions
         require_once( dirname( __FILE__ ) . '/inc/class.redux_functions.php' );
         require_once( dirname( __FILE__ ) . '/inc/class.p.php' );
+        require_once( dirname( __FILE__ ) . '/inc/class.redux_cookies.php' );
 
         require_once( dirname( __FILE__ ) . '/inc/class.redux_filesystem.php' );
 

--- a/ReduxCore/inc/class.redux_cookies.php
+++ b/ReduxCore/inc/class.redux_cookies.php
@@ -1,0 +1,31 @@
+<?php
+    if ( ! defined( 'ABSPATH' ) ) {
+        exit;
+    }
+
+    if (!class_exists('reduxCookie')) {
+
+        /**
+         * Cookie class wrapper.
+         * @author daithi coombes
+         */
+        class reduxCookie {
+
+            /**
+             * Set a cookie.
+             * Do nothing if unit testing.
+             * @param string $name The cookie name.
+             * @param string $value The cookie value.
+             * @param integer $expire Expiry time.
+             * @param string $path The cookie path.
+             * @param string $domain The cookie domain.
+             * @param boolean $secure HTTPS only.
+             * @param boolean $httponly Only set cookie on HTTP calls.
+             */
+            public static function setCookie( $name, $value, $expire = 0, $path, $domain=null, $secure = false, $httponly = false ){
+
+                if ( ! defined( 'WP_TESTS_DOMAIN' ) )
+                    setcookie( $name, $value, $expire, $path, $domain, $secure, $httponly );
+            }
+        }
+    }

--- a/ReduxCore/inc/welcome/welcome.php
+++ b/ReduxCore/inc/welcome/welcome.php
@@ -84,7 +84,7 @@
                 } else if ( version_compare( $curVer, $saveVer, '>' ) ) {
                     $redirect = true; // Previous version
                 }
-                if ( $redirect ) {
+                if ( $redirect && ! defined( 'WP_TESTS_DOMAIN' ) ) {
                     add_action('init', array($this, 'do_redirect'));
                 }
             }
@@ -92,9 +92,9 @@
 
         public function do_redirect() {
             wp_redirect( admin_url( 'tools.php?page=redux-about' ) );
-            exit();            
+            exit();
         }
-        
+
         public function change_wp_footer() {
             echo 'If you like <strong>Redux</strong> please leave us a <a href="https://wordpress.org/support/view/plugin-reviews/redux-framework?filter=5#postform" target="_blank" class="redux-rating-link" data-rated="Thanks :)">★★★★★</a> rating. A huge thank you from Redux in advance!';
         }
@@ -561,4 +561,3 @@
     }
 
     new Redux_Welcome();
-

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
   "name": "redux-framework/redux-framework",
+  "verson": "3.5.4.1",
   "authors": [
     {
       "name": "Team Redux"


### PR DESCRIPTION
This `pr` is to fix: [cant run with `phpunit`: PHP Warning: `headers already sent by (output started at bootstrap.php:53) pluggable.php on line 1196`](https://github.com/reduxframework/redux-framework/issues/2265) . 

I've found that the main issue that was causing my plugin unit tests to fail was the use of php `setcookies()` function writing `headers()`, to solve this I created a `reduxCookie` class that I could mock or overwrite in my unit tests.

I've also added the following to the `pr`:
 - composer version number 8a94c53
 - unit testing instructions in `condributing.md` cb7b9f2
 - `reduxCookie` class 3193533