### PR TITLE
Updated render actions to pass arguments by reference so hooks can update data

### DIFF
--- a/ReduxCore/framework.php
+++ b/ReduxCore/framework.php
@@ -1671,14 +1671,14 @@
 
 //                if ($this->args['sass']['enabled']) {
 //                    $ret = reduxSassCompiler::compile_sass($this);
-//                    
+//
 //                    if ($ret == reduxSassCompiler::SASS_FILE_COMPILE || $ret == reduxSassCompiler::SASS_NO_COMPILE) {
 //                        if (file_exists(ReduxFramework::$_upload_dir . $this->args['opt_name'] .  '-redux.css')) {
 //                            wp_enqueue_style(
-//                                'redux-fields-css', 
-//                                ReduxFramework::$_upload_url . $this->args['opt_name'] .  '-redux.css', 
-//                                array(), 
-//                                $timestamp, 
+//                                'redux-fields-css',
+//                                ReduxFramework::$_upload_url . $this->args['opt_name'] .  '-redux.css',
+//                                array(),
+//                                $timestamp,
 //                                'all'
 //                            );
 //                        }
@@ -3246,7 +3246,7 @@
                      * @param array  $field field data
                      * @param string $value field.id
                      */
-                    do_action( "redux/field/{$this->args['opt_name']}/{$field['type']}/callback/before", $field, $value );
+                    do_action_ref_array( "redux/field/{$this->args['opt_name']}/{$field['type']}/callback/before", array( &$field, &$value ) );
 
                     /**
                      * action 'redux/field/{opt_name}/callback/before'
@@ -3254,7 +3254,7 @@
                      * @param array  $field field data
                      * @param string $value field.id
                      */
-                    do_action( "redux/field/{$this->args['opt_name']}/callback/before", $field, $value );
+                    do_action_ref_array( "redux/field/{$this->args['opt_name']}/callback/before", array( &$field, &$value ) );
 
                     call_user_func( $field['callback'], $field, $value );
 
@@ -3275,7 +3275,7 @@
                      * @param array  $field field data
                      * @param string $value field.id
                      */
-                    do_action( "redux/field/{$this->args['opt_name']}/{$field['type']}/callback/after", $field, $value );
+                    do_action_ref_array( "redux/field/{$this->args['opt_name']}/{$field['type']}/callback/after", array( &$field, &$value ) );
 
                     /**
                      * action 'redux/field/{opt_name}/callback/after'
@@ -3283,7 +3283,8 @@
                      * @param array  $field field data
                      * @param string $value field.id
                      */
-                    do_action( "redux/field/{$this->args['opt_name']}/callback/after", $field, $value );
+                    do_action_ref_array( "redux/field/{$this->args['opt_name']}/callback/after", array( &$field, &$value ) );
+
 
                     return;
                 }
@@ -3344,7 +3345,7 @@
                          * @param array  $field field data
                          * @param string $value field id
                          */
-                        do_action( "redux/field/{$this->args['opt_name']}/{$field['type']}/render/before", $field, $value );
+                        do_action_ref_array( "redux/field/{$this->args['opt_name']}/{$field['type']}/render/before", array( &$field, &$value ) );
 
                         /**
                          * action 'redux/field/{$this->args['opt_name']}/render/before'
@@ -3352,7 +3353,7 @@
                          * @param array  $field field data
                          * @param string $value field id
                          */
-                        do_action( "redux/field/{$this->args['opt_name']}/render/before", $field, $value );
+                        do_action_ref_array( "redux/field/{$this->args['opt_name']}/render/before", array( &$field, &$value ) );
 
                         if ( ! isset ( $field['name_suffix'] ) ) {
                             $field['name_suffix'] = "";
@@ -3413,7 +3414,7 @@
                          * @param array  $field field data
                          * @param string $value field id
                          */
-                        do_action( "redux/field/{$this->args['opt_name']}/{$field['type']}/fieldset/before/{$this->args['opt_name']}", $field, $value );
+                        do_action_ref_array( "redux/field/{$this->args['opt_name']}/{$field['type']}/fieldset/before/{$this->args['opt_name']}", array( &$field, &$value ) );
 
                         /**
                          * action 'redux/field/{opt_name}/fieldset/before/{opt_name}'
@@ -3421,7 +3422,7 @@
                          * @param array  $field field data
                          * @param string $value field id
                          */
-                        do_action( "redux/field/{$this->args['opt_name']}/fieldset/before/{$this->args['opt_name']}", $field, $value );
+                        do_action_ref_array( "redux/field/{$this->args['opt_name']}/fieldset/before/{$this->args['opt_name']}", array( &$field, &$value ) );
 
                         //if ( ! isset( $field['fields'] ) || empty( $field['fields'] ) ) {
                         $hidden = '';
@@ -3464,7 +3465,7 @@
                          * @param array  $field field data
                          * @param string $value field id
                          */
-                        do_action( "redux/field/{$this->args['opt_name']}/{$field['type']}/fieldset/after/{$this->args['opt_name']}", $field, $value );
+                        do_action_ref_array( "redux/field/{$this->args['opt_name']}/{$field['type']}/fieldset/after/{$this->args['opt_name']}", array( &$field, &$value ) );
 
                         /**
                          * action 'redux/field/{opt_name}/fieldset/after/{opt_name}'
@@ -3472,7 +3473,7 @@
                          * @param array  $field field data
                          * @param string $value field id
                          */
-                        do_action( "redux/field/{$this->args['opt_name']}/fieldset/after/{$this->args['opt_name']}", $field, $value );
+                        do_action_ref_array( "redux/field/{$this->args['opt_name']}/fieldset/after/{$this->args['opt_name']}", array( &$field, &$value ) );
                     }
                 }
             }


### PR DESCRIPTION
I updated the render actions to use ```do_action_ref_array``` so the data passed can be updated by hooks.  Before this there was no other way to modify field data before it was rendered.