### PR TITLE
Allows the disable_tracking flag regardless of theme or plugin

### DIFF
--- a/ReduxCore/framework.php
+++ b/ReduxCore/framework.php
@@ -25,7 +25,7 @@
     if ( has_action( 'ecpt_field_options_' ) ) {
         global $pagenow;
         if ( $pagenow === 'admin.php' ) {
-            
+
             remove_action( 'admin_init', 'pb_admin_init' );
         }
     }
@@ -335,7 +335,7 @@
                     $this->get_options();
 
                     // Tracking
-                    if ( true != Redux_Helpers::isTheme( __FILE__ ) || ( true == Redux_Helpers::isTheme( __FILE__ ) && ! $this->args['disable_tracking'] ) ) {
+                    if ( ! $this->args['disable_tracking'] ) {
                         $this->_tracking();
                     }
 


### PR DESCRIPTION
Would it be possible for us to allow the disable_tracking flag to be respected regardless of whether Redux is embedded in a theme versus embedded in a plugin or used as a standalone plugin?

Per contributing guidelines...
1. I'm using Redux 3.5.4.3 (current WordPress repo version)
2. I'm using WordPress 4.2.2
3. I'm using Redux in Dev mode
4. n/a
5. n/a
6. Tried using Redux both as a standalone plugin but also tried embedding it in my own plugin
7. n/a 