### PR TITLE
Updated color_rgba to use the field name provided to it instead of creating its own

### DIFF
--- a/ReduxCore/inc/fields/checkbox/field_checkbox.php
+++ b/ReduxCore/inc/fields/checkbox/field_checkbox.php
@@ -61,13 +61,13 @@ if ( !class_exists ( 'ReduxFramework_checkbox' ) ) {
                 if (empty($this->field['args'])) {
                     $this->field['args'] = array();
                 }
-                
+
                 $this->field['options'] = $this->parent->get_wordpress_data($this->field['data'], $this->field['args']);
                 if (empty($this->field['options'])) {
                     return;
                 }
             }
-            
+
             $this->field[ 'data_class' ] = ( isset ( $this->field[ 'multi_layout' ] ) ) ? 'data-' . $this->field[ 'multi_layout' ] : 'data-full';
 
             if ( !empty ( $this->field[ 'options' ] ) && ( is_array ( $this->field[ 'options' ] ) || is_array ( $this->field[ 'default' ] ) ) ) {
@@ -120,7 +120,9 @@ if ( !class_exists ( 'ReduxFramework_checkbox' ) ) {
                 echo '<input type="checkbox" id="' . strtr ( $this->parent->args[ 'opt_name' ] . '[' . $this->field[ 'id' ] . ']', array(
                     '[' => '_',
                     ']' => ''
-                ) ) . '" value="1" class="checkbox ' . $this->field[ 'class' ] . '" ' . checked ( $this->value, '1', false ) . '/></li></ul>';
+                ) ) . '" value="1" class="checkbox ' . $this->field[ 'class' ] . '" ' . checked ( $this->value, '1', false ) . '/>';
+                echo isset( $this->field[ 'label' ] ) ? ' ' . $this->field[ 'label' ] : '';
+                echo '</label></li></ul>';
             }
         }
 
@@ -136,19 +138,19 @@ if ( !class_exists ( 'ReduxFramework_checkbox' ) ) {
 
             if ($this->parent->args['dev_mode']) {
                 wp_enqueue_style (
-                    'redux-field-checkbox-css', 
-                    ReduxFramework::$_url . 'inc/fields/checkbox/field_checkbox.css', 
+                    'redux-field-checkbox-css',
+                    ReduxFramework::$_url . 'inc/fields/checkbox/field_checkbox.css',
                     array(),
-                    time (), 
+                    time (),
                     'all'
                 );
             }
-            
+
             wp_enqueue_script (
-                'redux-field-checkbox-js', 
-                ReduxFramework::$_url . 'inc/fields/checkbox/field_checkbox' . Redux_Functions::isMin () . '.js', 
-                array( 'jquery', 'redux-js' ), 
-                time (), 
+                'redux-field-checkbox-js',
+                ReduxFramework::$_url . 'inc/fields/checkbox/field_checkbox' . Redux_Functions::isMin () . '.js',
+                array( 'jquery', 'redux-js' ),
+                time (),
                 true
             );
         }

--- a/ReduxCore/inc/fields/color_rgba/field_color_rgba.php
+++ b/ReduxCore/inc/fields/color_rgba/field_color_rgba.php
@@ -34,7 +34,7 @@ if( !class_exists( 'ReduxFramework_color_rgba' ) ) {
      * @since       1.0.0
      */
     class ReduxFramework_color_rgba {
-    
+
       /**
        * Class Constructor. Defines the args for the extions class
        *
@@ -74,14 +74,14 @@ if( !class_exists( 'ReduxFramework_color_rgba' ) ) {
             $this->field['options']['show_buttons']            = isset($this->field['options']['show_buttons']) ? $this->field['options']['show_buttons'] : true;
             $this->field['options']['palette']                 = isset($this->field['options']['palette']) ? $this->field['options']['palette'] : null;
             $this->field['options']['input_text']              = isset($this->field['options']['input_text']) ? $this->field['options']['input_text'] : 'Select Color';
-            
+
             // Convert empty array to null, if there.
             $this->field['options']['palette']                 = empty($this->field['options']['palette']) ? null : $this->field['options']['palette'];
-            
+
             $this->field['output_transparent']                 = isset($this->field['output_transparent']) ? $this->field['output_transparent'] : false;
         }
 
-        
+
         /**
          * Field Render Function.
          *
@@ -92,29 +92,30 @@ if( !class_exists( 'ReduxFramework_color_rgba' ) ) {
          * @return      void
          */
         public function render() {
-            
+
             $field_id = $this->field['id'];
-            
+            $name = $this->field['name'] . $this->field['name_suffix'];
+
             // Color picker container
-            echo '<div 
-                      class="redux-color-rgba-container ' . $this->field['class'] . '" 
-                      data-id="'                        . $field_id . '"
-                      data-show-input="'                . $this->field['options']['show_input'] . '"
-                      data-show-initial="'              . $this->field['options']['show_initial'] . '"
-                      data-show-alpha="'                . $this->field['options']['show_alpha'] . '"
-                      data-show-palette="'              . $this->field['options']['show_palette'] . '"
-                      data-show-palette-only="'         . $this->field['options']['show_palette_only'] . '"
-                      data-show-selection-palette="'    . $this->field['options']['show_selection_palette'] . '"
-                      data-max-palette-size="'          . $this->field['options']['max_palette_size'] . '"
-                      data-allow-empty="'               . $this->field['options']['allow_empty'] . '"
-                      data-clickout-fires-change="'     . $this->field['options']['clickout_fires_change'] . '"
-                      data-choose-text="'               . $this->field['options']['choose_text'] . '"
-                      data-cancel-text="'               . $this->field['options']['cancel_text'] . '"
-                      data-input-text="'                . $this->field['options']['input_text'] . '"
-                      data-show-buttons="'              . $this->field['options']['show_buttons'] . '"
-                      data-palette="'                   . urlencode(json_encode($this->field['options']['palette'])) . '"
+            echo '<div
+                      class="redux-color-rgba-container ' . $this->field['class'] . '"
+                      data-id="'                          . $field_id . '"
+                      data-show-input="'                  . $this->field['options']['show_input'] . '"
+                      data-show-initial="'                . $this->field['options']['show_initial'] . '"
+                      data-show-alpha="'                  . $this->field['options']['show_alpha'] . '"
+                      data-show-palette="'                . $this->field['options']['show_palette'] . '"
+                      data-show-palette-only="'           . $this->field['options']['show_palette_only'] . '"
+                      data-show-selection-palette="'      . $this->field['options']['show_selection_palette'] . '"
+                      data-max-palette-size="'            . $this->field['options']['max_palette_size'] . '"
+                      data-allow-empty="'                 . $this->field['options']['allow_empty'] . '"
+                      data-clickout-fires-change="'       . $this->field['options']['clickout_fires_change'] . '"
+                      data-choose-text="'                 . $this->field['options']['choose_text'] . '"
+                      data-cancel-text="'                 . $this->field['options']['cancel_text'] . '"
+                      data-input-text="'                  . $this->field['options']['input_text'] . '"
+                      data-show-buttons="'                . $this->field['options']['show_buttons'] . '"
+                      data-palette="'                     . urlencode(json_encode($this->field['options']['palette'])) . '"
                   >';
-            
+
             // Colour picker layout
             $opt_name = $this->parent->args['opt_name'];
 
@@ -122,14 +123,14 @@ if( !class_exists( 'ReduxFramework_color_rgba' ) ) {
                 $color = '';
             } else {
                 $color = Redux_Helpers::hex2rgba($this->value['color'], $this->value['alpha']);
-            }            
+            }
 
             if ($this->value['rgba'] == ''){
                 $this->value['rgba'] = Redux_Helpers::hex2rgba($this->value['color'], $this->value['alpha']);
             }
-            
+
             echo '<input
-                        name="' . $opt_name . '[' . $field_id . '][color]"
+                        name="' . $name . '[color]"
                         id="' . $field_id . '-color"
                         class="redux-color-rgba"
                         type="text"
@@ -139,7 +140,7 @@ if( !class_exists( 'ReduxFramework_color_rgba' ) ) {
                         data-current-color="' . $this->value['color'] . '"
                         data-block-id="' . $field_id . '"
                         data-output-transparent="' . $this->field['output_transparent'] . '"
-                      />';            
+                      />';
 
             echo '<input
                         type="hidden"
@@ -147,14 +148,14 @@ if( !class_exists( 'ReduxFramework_color_rgba' ) ) {
                         data-id="' . $field_id . '-color"
                         id="' . $field_id . '-color"
                         value="' . $this->value['color'] . '"
-                      />';            
+                      />';
 
             // Hidden input for alpha channel
             echo '<input
                         type="hidden"
                         class="redux-hidden-alpha"
                         data-id="' . $field_id . '-alpha"
-                        name="' . $opt_name . '[' . $field_id . '][alpha]' .  '"
+                        name="' . $name . '[alpha]' .  '"
                         id="' . $field_id . '-alpha"
                         value="' . $this->value['alpha'] . '"
                       />';
@@ -164,14 +165,14 @@ if( !class_exists( 'ReduxFramework_color_rgba' ) ) {
                         type="hidden"
                         class="redux-hidden-rgba"
                         data-id="' . $field_id . '-rgba"
-                        name="' . $opt_name . '[' . $field_id . '][rgba]' .  '"
+                        name="' . $name . '[rgba]' .  '"
                         id="' . $field_id . '-rgba"
                         value="' . $this->value['rgba'] . '"
-                      />';             
-            
+                      />';
+
             echo '</div>';
         }
-        
+
         /**
          * Enqueue Function.
          *
@@ -182,26 +183,26 @@ if( !class_exists( 'ReduxFramework_color_rgba' ) ) {
          * @return      void
          */
         public function enqueue() {
-            
+
             // Set up min files for dev_mode = false.
             $min = Redux_Functions::isMin();
 
             // Field dependent JS
             if (!wp_script_is ( 'redux-field-color-rgba-js' )) {
                 wp_enqueue_script(
-                    'redux-field-color-rgba-js', 
+                    'redux-field-color-rgba-js',
                     ReduxFramework::$_url . 'inc/fields/color_rgba/field_color_rgba' . Redux_Functions::isMin() . '.js',
-                    array('jquery', 'redux-spectrum-js'), 
-                    time(), 
+                    array('jquery', 'redux-spectrum-js'),
+                    time(),
                     true
                 );
             }
-            
+
             // Spectrum CSS
             if (!wp_style_is ( 'redux-spectrum-css' )) {
                 wp_enqueue_style('redux-spectrum-css');
             }
-            
+
             if ($this->parent->args['dev_mode']) {
                 if (!wp_style_is ( 'redux-field-color-rgba-css' )) {
                     wp_enqueue_style(
@@ -223,9 +224,9 @@ if( !class_exists( 'ReduxFramework_color_rgba' ) ) {
          * @since       1.0.0
          * @access      private
          * @return      string
-         */        
+         */
         private function getColorVal(){
-            
+
             // No notices
             $color  = '';
             $alpha  = 1;
@@ -247,16 +248,16 @@ if( !class_exists( 'ReduxFramework_color_rgba' ) ) {
                         $rgba = Redux_Helpers::hex2rgba($color, $alpha);
                     }
                 }
-                
+
                 // Only build rgba output if alpha ia less than 1
                 if ( $alpha < 1 && $alpha <> '' ) {
                     $color = $rgba;
                 }
             }
-            
+
             return $color;
         }
-        
+
         /**
          * Output Function.
          *
@@ -265,17 +266,17 @@ if( !class_exists( 'ReduxFramework_color_rgba' ) ) {
          * @since       1.0.0
          * @access      public
          * @return      void
-         */        
+         */
         public function output() {
             if (!empty($this->value)) {
                 $style = '';
-                
+
                 $mode = ( isset( $this->field['mode'] ) && ! empty( $this->field['mode'] ) ? $this->field['mode'] : 'color' );
-                
+
                 $color_val = $this->getColorVal();
-                
+
                 $style .= $mode . ':' . $color_val . ';';
-                
+
                 if ( ! empty( $this->field['output'] ) && is_array( $this->field['output'] ) ) {
                     $css = Redux_Functions::parseCSS( $this->field['output'], $style, $color_val );
                     $this->parent->outputCSS .= $css;

--- a/ReduxCore/inc/fields/color_rgba/field_color_rgba.php
+++ b/ReduxCore/inc/fields/color_rgba/field_color_rgba.php
@@ -94,25 +94,26 @@ if( !class_exists( 'ReduxFramework_color_rgba' ) ) {
         public function render() {
 
             $field_id = $this->field['id'];
+            $name = $this->field['name'] . $this->field['name_suffix'];
 
             // Color picker container
             echo '<div
-                      class="redux-color-rgba-container' . $this->field['class'] . '"
-                      data-id="'                        . $field_id . '"
-                      data-show-input="'                . $this->field['options']['show_input'] . '"
-                      data-show-initial="'              . $this->field['options']['show_initial'] . '"
-                      data-show-alpha="'                . $this->field['options']['show_alpha'] . '"
-                      data-show-palette="'              . $this->field['options']['show_palette'] . '"
-                      data-show-palette-only="'         . $this->field['options']['show_palette_only'] . '"
-                      data-show-selection-palette="'    . $this->field['options']['show_selection_palette'] . '"
-                      data-max-palette-size="'          . $this->field['options']['max_palette_size'] . '"
-                      data-allow-empty="'               . $this->field['options']['allow_empty'] . '"
-                      data-clickout-fires-change="'     . $this->field['options']['clickout_fires_change'] . '"
-                      data-choose-text="'               . $this->field['options']['choose_text'] . '"
-                      data-cancel-text="'               . $this->field['options']['cancel_text'] . '"
-                      data-input-text="'                . $this->field['options']['input_text'] . '"
-                      data-show-buttons="'              . $this->field['options']['show_buttons'] . '"
-                      data-palette="'                   . urlencode(json_encode($this->field['options']['palette'])) . '"
+                      class="redux-color-rgba-container ' . $this->field['class'] . '"
+                      data-id="'                          . $field_id . '"
+                      data-show-input="'                  . $this->field['options']['show_input'] . '"
+                      data-show-initial="'                . $this->field['options']['show_initial'] . '"
+                      data-show-alpha="'                  . $this->field['options']['show_alpha'] . '"
+                      data-show-palette="'                . $this->field['options']['show_palette'] . '"
+                      data-show-palette-only="'           . $this->field['options']['show_palette_only'] . '"
+                      data-show-selection-palette="'      . $this->field['options']['show_selection_palette'] . '"
+                      data-max-palette-size="'            . $this->field['options']['max_palette_size'] . '"
+                      data-allow-empty="'                 . $this->field['options']['allow_empty'] . '"
+                      data-clickout-fires-change="'       . $this->field['options']['clickout_fires_change'] . '"
+                      data-choose-text="'                 . $this->field['options']['choose_text'] . '"
+                      data-cancel-text="'                 . $this->field['options']['cancel_text'] . '"
+                      data-input-text="'                  . $this->field['options']['input_text'] . '"
+                      data-show-buttons="'                . $this->field['options']['show_buttons'] . '"
+                      data-palette="'                     . urlencode(json_encode($this->field['options']['palette'])) . '"
                   >';
 
             // Colour picker layout
@@ -129,7 +130,7 @@ if( !class_exists( 'ReduxFramework_color_rgba' ) ) {
             }
 
             echo '<input
-                        name="' . $opt_name . '[' . $field_id . '][color]"
+                        name="' . $name . '[color]"
                         id="' . $field_id . '-color"
                         class="redux-color-rgba"
                         type="text"
@@ -154,7 +155,7 @@ if( !class_exists( 'ReduxFramework_color_rgba' ) ) {
                         type="hidden"
                         class="redux-hidden-alpha"
                         data-id="' . $field_id . '-alpha"
-                        name="' . $opt_name . '[' . $field_id . '][alpha]' .  '"
+                        name="' . $name . '[alpha]' .  '"
                         id="' . $field_id . '-alpha"
                         value="' . $this->value['alpha'] . '"
                       />';
@@ -164,7 +165,7 @@ if( !class_exists( 'ReduxFramework_color_rgba' ) ) {
                         type="hidden"
                         class="redux-hidden-rgba"
                         data-id="' . $field_id . '-rgba"
-                        name="' . $opt_name . '[' . $field_id . '][rgba]' .  '"
+                        name="' . $name . '[rgba]' .  '"
                         id="' . $field_id . '-rgba"
                         value="' . $this->value['rgba'] . '"
                       />';

--- a/ReduxCore/inc/fields/color_rgba/field_color_rgba.php
+++ b/ReduxCore/inc/fields/color_rgba/field_color_rgba.php
@@ -94,26 +94,25 @@ if( !class_exists( 'ReduxFramework_color_rgba' ) ) {
         public function render() {
 
             $field_id = $this->field['id'];
-            $name = $this->field['name'] . $this->field['name_suffix'];
 
             // Color picker container
             echo '<div
-                      class="redux-color-rgba-container ' . $this->field['class'] . '"
-                      data-id="'                          . $field_id . '"
-                      data-show-input="'                  . $this->field['options']['show_input'] . '"
-                      data-show-initial="'                . $this->field['options']['show_initial'] . '"
-                      data-show-alpha="'                  . $this->field['options']['show_alpha'] . '"
-                      data-show-palette="'                . $this->field['options']['show_palette'] . '"
-                      data-show-palette-only="'           . $this->field['options']['show_palette_only'] . '"
-                      data-show-selection-palette="'      . $this->field['options']['show_selection_palette'] . '"
-                      data-max-palette-size="'            . $this->field['options']['max_palette_size'] . '"
-                      data-allow-empty="'                 . $this->field['options']['allow_empty'] . '"
-                      data-clickout-fires-change="'       . $this->field['options']['clickout_fires_change'] . '"
-                      data-choose-text="'                 . $this->field['options']['choose_text'] . '"
-                      data-cancel-text="'                 . $this->field['options']['cancel_text'] . '"
-                      data-input-text="'                  . $this->field['options']['input_text'] . '"
-                      data-show-buttons="'                . $this->field['options']['show_buttons'] . '"
-                      data-palette="'                     . urlencode(json_encode($this->field['options']['palette'])) . '"
+                      class="redux-color-rgba-container' . $this->field['class'] . '"
+                      data-id="'                        . $field_id . '"
+                      data-show-input="'                . $this->field['options']['show_input'] . '"
+                      data-show-initial="'              . $this->field['options']['show_initial'] . '"
+                      data-show-alpha="'                . $this->field['options']['show_alpha'] . '"
+                      data-show-palette="'              . $this->field['options']['show_palette'] . '"
+                      data-show-palette-only="'         . $this->field['options']['show_palette_only'] . '"
+                      data-show-selection-palette="'    . $this->field['options']['show_selection_palette'] . '"
+                      data-max-palette-size="'          . $this->field['options']['max_palette_size'] . '"
+                      data-allow-empty="'               . $this->field['options']['allow_empty'] . '"
+                      data-clickout-fires-change="'     . $this->field['options']['clickout_fires_change'] . '"
+                      data-choose-text="'               . $this->field['options']['choose_text'] . '"
+                      data-cancel-text="'               . $this->field['options']['cancel_text'] . '"
+                      data-input-text="'                . $this->field['options']['input_text'] . '"
+                      data-show-buttons="'              . $this->field['options']['show_buttons'] . '"
+                      data-palette="'                   . urlencode(json_encode($this->field['options']['palette'])) . '"
                   >';
 
             // Colour picker layout
@@ -130,7 +129,7 @@ if( !class_exists( 'ReduxFramework_color_rgba' ) ) {
             }
 
             echo '<input
-                        name="' . $name . '[color]"
+                        name="' . $opt_name . '[' . $field_id . '][color]"
                         id="' . $field_id . '-color"
                         class="redux-color-rgba"
                         type="text"
@@ -155,7 +154,7 @@ if( !class_exists( 'ReduxFramework_color_rgba' ) ) {
                         type="hidden"
                         class="redux-hidden-alpha"
                         data-id="' . $field_id . '-alpha"
-                        name="' . $name . '[alpha]' .  '"
+                        name="' . $opt_name . '[' . $field_id . '][alpha]' .  '"
                         id="' . $field_id . '-alpha"
                         value="' . $this->value['alpha'] . '"
                       />';
@@ -165,7 +164,7 @@ if( !class_exists( 'ReduxFramework_color_rgba' ) ) {
                         type="hidden"
                         class="redux-hidden-rgba"
                         data-id="' . $field_id . '-rgba"
-                        name="' . $name . '[rgba]' .  '"
+                        name="' . $opt_name . '[' . $field_id . '][rgba]' .  '"
                         id="' . $field_id . '-rgba"
                         value="' . $this->value['rgba'] . '"
                       />';


### PR DESCRIPTION
Updated color_rgba field to use the field name provided to it instead of creating its own.

The field was creating its own name which was causing incorrect output when used inside a repeater field.

Before:
```
            [color-rgba-0] => Array
                (
                    [color] => #a5a68d
                    [alpha] => 0.16
                    [rgba] => rgba(165,166,141,0.16)
                )

            [color-rgba-1] => Array
                (
                    [color] => #428f58
                    [alpha] => 0.8
                    [rgba] => rgba(66,143,88,0.8)
                )
```

After:
```
            [color-rgba] => Array
                (
                    [0] => Array
                        (
                            [color] => #a5a68d
                            [alpha] => 0.16
                            [rgba] => rgba(165,166,141,0.16)
                        )

                    [1] => Array
                        (
                            [color] => #428f58
                            [alpha] => 0.8
                            [rgba] => rgba(66,143,88,0.8)
                        )

                )
```

It will break any old code, but now it will be consistent with all the other fields.