### PR TITLE
Fixes Tracking

### DIFF
--- a/ReduxCore/framework.php
+++ b/ReduxCore/framework.php
@@ -339,7 +339,7 @@
                     $this->get_options();
 
                     // Tracking
-                    if ( true != Redux_Helpers::isTheme( __FILE__ ) || true == Redux_Helpers::isTheme( __FILE__ ) ) {
+                    if ( isset( $this->args[ 'allow_tracking' ] ) && $this->args[ 'allow_tracking' ] && Redux_Helpers::isTheme( __FILE__ ) ) {
                         $this->_tracking();
                     }
 


### PR DESCRIPTION
Right now, the framework does not respect the `allow_tracking` parameter, which is a serious bug (in terms of not only it not working) but also because of repository restrictions.

If `allow_tracking` is off, then it shouldn't even load the tracking script. This could get people into serious trouble on WordPress.org. Right now, tracking is loaded regardless of how the option is set, and the current if statement would always be true