### PR TITLE
Add missing argument to sample & barebone config

### DIFF
--- a/sample/barebones-config.php
+++ b/sample/barebones-config.php
@@ -52,8 +52,12 @@
         'global_variable'      => '',
         // Set a different name for your global variable other than the opt_name
         'dev_mode'             => true,
+		// If you are on localhost dev_mode will be set to true even if you set it to false set  forced_dev_mode_off to true to disable the dev mode
+		'forced_dev_mode_off' => false,
         // Show the time the page took to load, etc
         'update_notice'        => true,
+		//Show the options panel only in customzier not in wordpress dashboard
+		'customizer_only' => false,
         // If dev_mode is enabled, will notify developer of updated versions available in the GitHub Repo
         'customizer'           => true,
         // Enable basic customizer support

--- a/sample/barebones-config.php
+++ b/sample/barebones-config.php
@@ -56,7 +56,7 @@
 		'forced_dev_mode_off' => false,
         // Show the time the page took to load, etc
         'update_notice'        => true,
-		//Show the options panel only in customzier not in wordpress dashboard
+		//Show the options panel only in customizer not in wordpress dashboard
 		'customizer_only' => false,
         // If dev_mode is enabled, will notify developer of updated versions available in the GitHub Repo
         'customizer'           => true,

--- a/sample/sample-config.php
+++ b/sample/sample-config.php
@@ -94,13 +94,11 @@
         'global_variable'      => '',
         // Set a different name for your global variable other than the opt_name
         'dev_mode'             => true,
-		// If you are on localhost dev_mode will be set to true even if you set it to false set  forced_dev_mode_off to true to disable the dev mode
-		'forced_dev_mode_off' => false,
         // Show the time the page took to load, etc
         'update_notice'        => true,
         // If dev_mode is enabled, will notify developer of updated versions available in the GitHub Repo
         'customizer'           => true,
-		//Show the options panel only in customzier not in wordpress dashboard
+		//Show the options panel only in customizer not in wordpress dashboard
 		'customizer_only' => false,
         // Enable basic customizer support
         //'open_expanded'     => true,                    // Allow you to start the panel in an expanded way initially.

--- a/sample/sample-config.php
+++ b/sample/sample-config.php
@@ -94,10 +94,14 @@
         'global_variable'      => '',
         // Set a different name for your global variable other than the opt_name
         'dev_mode'             => true,
+		// If you are on localhost dev_mode will be set to true even if you set it to false set  forced_dev_mode_off to true to disable the dev mode
+		'forced_dev_mode_off' => false,
         // Show the time the page took to load, etc
         'update_notice'        => true,
         // If dev_mode is enabled, will notify developer of updated versions available in the GitHub Repo
         'customizer'           => true,
+		//Show the options panel only in customzier not in wordpress dashboard
+		'customizer_only' => false,
         // Enable basic customizer support
         //'open_expanded'     => true,                    // Allow you to start the panel in an expanded way initially.
         //'disable_save_warn' => true,                    // Disable the save warning when a user changes a field


### PR DESCRIPTION
At least put the args here https://docs.reduxframework.com/core/arguments/ the devs need to know about those two.About the dev in the sample that was a bad idea don't know why I didn't think at that,