### PR TITLE
Update framework.php to check get_terms returned an WP_Error Object

### DIFF
--- a/ReduxCore/framework.php
+++ b/ReduxCore/framework.php
@@ -934,7 +934,7 @@
                             $taxonomies = $args['taxonomies'];
                             unset ( $args['taxonomies'] );
                             $terms = get_terms( $taxonomies, $args ); // this will get nothing
-                            if ( ! empty ( $terms ) ) {
+                            if ( ! empty ( $terms ) && !is_a($terms,'WP_Error')) {
                                 foreach ( $terms as $term ) {
                                     $data[ $term->term_id ] = $term->name;
                                 }


### PR DESCRIPTION
get_terms may return an WP_Error Object on error , so check the returned is empty or WP_Error Object too avoid "trying to get property of non-object" error