### PR TITLE
Added check in field button_set for non-scalar values

### DIFF
--- a/ReduxCore/inc/fields/button_set/field_button_set.php
+++ b/ReduxCore/inc/fields/button_set/field_button_set.php
@@ -117,7 +117,12 @@
                     } else {
                         $multi_suffix = "";
                         $type         = "radio";
-                        $selected     = checked( $this->value, $k, false );
+
+                        if ( is_scalar( $this->value ) ) {
+                            $selected = checked( $this->value, $k, false );
+                        } else {
+                            $selected = false;
+                        }
                     }
 
                     echo '<input data-id="' . $this->field['id'] . '" type="' . $type . '" id="' . $this->field['id'] . '-buttonset' . $k . '" name="' . $this->field['name'] . $this->field['name_suffix'] . $multi_suffix . '" class="buttonset-item ' . $this->field['class'] . '" value="' . $k . '" ' . $selected . '/>';


### PR DESCRIPTION
The `checked()` function used inside the button_set field requires scalar values, however `$this->value` is an array() when using `'data'` on a field and only allowing a single option to be selected.

This adds a check that the value is scalar before trying to use it.

Field to recreate the issue:
```
              array(
                'id'        => 'budget',
                'type'      => 'button_set',
                'title'     => __( 'Budget' ),
                'data'      => 'terms',
                'args'      =>  array(
                  'taxonomies' => array( 'budget' ),
                  'hide_empty' => false,
                  'orderby'    => 'id',
                  'order'      => 'ASC',
                ),
                'associate' => array(
                  'taxonomy' => 'budget',
                ),
              ),
```