### PR TITLE
Enqueued Javascript for "Sortable" Select Field

### DIFF
--- a/ReduxCore/inc/fields/select/field_select.php
+++ b/ReduxCore/inc/fields/select/field_select.php
@@ -161,6 +161,16 @@ if ( ! class_exists( 'ReduxFramework_select' ) ) {
                 time(),
                 true
             );
+            
+            if ($this->field['sortable']) {
+                wp_enqueue_script(
+                    'redux-field-sortable-js',
+                    ReduxFramework::$_url . 'inc/fields/sortable/field_sortable' . Redux_Functions::isMin() . '.js',
+                    array( 'jquery', 'redux-js', 'jquery-ui-sortable' ),
+                    time(),
+                    true
+                );
+            } 
 
             if ($this->parent->args['dev_mode']) {
                 wp_enqueue_style(


### PR DESCRIPTION
Sortable select fields would work on pages where other sortable fields were enqueueing the "sortable" javascript files, but when a select field with sortable enabled was alone on an options page, the proper javascript files were not being enqueued, thus resulting in an "un-sortable" select field.

Enqueueing the sortable scripts when a select field with "sortable" set to "true" fixes it.