### PR TITLE
Bugfix: make _extension_url contain correct url in all cases

### DIFF
--- a/ReduxCore/inc/extensions/customizer/extension_customizer.php
+++ b/ReduxCore/inc/extensions/customizer/extension_customizer.php
@@ -85,6 +85,12 @@
                 if ( empty( $this->_extension_dir ) ) {
                     $this->_extension_dir = trailingslashit( str_replace( '\\', '/', dirname( __FILE__ ) ) );
                     $this->_extension_url = site_url( str_replace( trailingslashit( str_replace( '\\', '/', ABSPATH ) ), '/', $this->_extension_dir ) );
+
+                    // Easier to read and less buggy way to find out correct url, but applicable
+                    // only if wp-content found. Othewise fall back to old URL detection code.
+                    if (preg_match("/wp-content\/(.*)/", $this->_extension_dir, $match)) {
+                        $this->_extension_url = site_url('/wp-content/'.$match[1]);
+                    }
                 }
 
                 self::get_post_values();


### PR DESCRIPTION
The old code populated _extension_url with contents like
https://example.org/var/www/sites/htdocs/wp-content/plugins/redux-framework/
-> ReduxCore/inc/extensions/customizer/

New implementation is does not mind if Redux is embedded in a theme or plugin,
supports having WordPress installed in any directory and to avoid future bugs:
the new code is clean and easy to read.