### PR TITLE
fixing the `extension_url` with WP core in another directory

### DIFF
--- a/ReduxCore/inc/extensions/customizer/extension_customizer.php
+++ b/ReduxCore/inc/extensions/customizer/extension_customizer.php
@@ -88,7 +88,11 @@
                     
                     if (preg_match("/wp-content\/(.*)/", $this->_extension_dir, $match)) {
                         $this->_extension_url = site_url('/wp-content/'.$match[1]);
-                    }                    
+                    }
+                    
+                    if ( defined('WP_CONTENT_DIR') && defined('WP_CONTENT_URL') ) {
+                        $this->_extension_url = WP_CONTENT_URL .  str_replace( trailingslashit( str_replace( '\\', '/', WP_CONTENT_DIR ) ), '/', $this->_extension_dir );
+                    }
                 }
 
                 self::get_post_values();


### PR DESCRIPTION
In the current implementation, the `extension_url` is not set corretly, when the WordPress core has it's own subfolder such as `wp` which is totally fine and often found when using a Git submodule or composer setup for WordPress which many professional developers use.