### PR TITLE
Edited framework.php

### DIFF
--- a/ReduxCore/framework.php
+++ b/ReduxCore/framework.php
@@ -3959,7 +3959,7 @@
                         foreach($this->args['admin_bar_links'] as $idx => $arr) {
                             if (is_array($arr) && !empty($arr)) {
                                 foreach($arr as $x => $y) {
-                                    if (strpos(strtolower($y), 'redux') >= 0) {
+                                    if (strpos(strtolower($y), 'redux') !== false) {
                                         $msg = __('<strong>Redux Framework Notice: </strong>There are references to the Redux Framework support site in your config\'s <code>admin_bar_links</code> argument.  This is sample data.  Please change or remove this data before shipping your product.', 'redux-framework');
                                         $this->display_arg_change_notice('admin', $msg);
                                         $this->omit_admin_items = true;


### PR DESCRIPTION
In dev_mode, if you have share_icons defined you always get the notice of "sample data" even if the definition doesn't contain any "redux" string