### PR TITLE
Fixed translation bug for themes and multisite

### DIFF
--- a/ReduxCore/framework.php
+++ b/ReduxCore/framework.php
@@ -637,7 +637,21 @@
 
                 $basepath = apply_filters( "redux/textdomain/basepath/{$this->args['opt_name']}", $basepath );
 
-                load_plugin_textdomain( 'redux-framework', false, $basepath . 'languages' );
+                $loaded = load_plugin_textdomain( 'redux-framework', false, $basepath . 'languages');
+
+                if ( !$loaded ){
+                    $loaded = load_muplugin_textdomain( 'redux-framework', $basepath . 'languages' );
+                }
+
+                if ( !$loaded ){
+                    $loaded = load_theme_textdomain( 'redux-framework', $basepath . 'languages' );
+                }
+
+                if ( ! $loaded ) {
+                    $locale = apply_filters( 'plugin_locale', get_locale(), 'redux-framework' );
+                    $mofile = dirname( __FILE__ ) . '/languages/redux-framework-' . $locale . '.mo';
+                    load_textdomain( 'redux-framework', $mofile );
+                }
             }
             // _internationalization()
 


### PR DESCRIPTION
I made a fix that in my view may be a bug. When used as plugins translations worked perfectly, but when used along with the theme or multisite, translations did not work, after amendment I made, translations back to work.