### PR TITLE
Revert "Remove old WP deprecated calls for new ones."

### DIFF
--- a/ReduxCore/inc/class.redux_helpers.php
+++ b/ReduxCore/inc/class.redux_helpers.php
@@ -148,7 +148,7 @@
                     'php'       => $version,
                     'site'      => array(
                         'hash'      => $hash,
-                        'version'   => bloginfo( 'version' ),
+                        'version'   => get_bloginfo( 'version' ),
                         'multisite' => is_multisite(),
                         'users'     => $user_query->get_total(),
                         'lang'      => get_locale(),
@@ -391,7 +391,7 @@
                 // Only is a file-write check
                 $sysinfo['redux_data_writeable'] = self::makeBoolStr( @$f( ReduxFramework::$_upload_dir . 'test-log.log', 'a' ) );
                 $sysinfo['wp_content_url']       = WP_CONTENT_URL;
-                $sysinfo['wp_ver']               = bloginfo( 'version' );
+                $sysinfo['wp_ver']               = get_bloginfo( 'version' );
                 $sysinfo['wp_multisite']         = is_multisite();
                 $sysinfo['permalink_structure']  = get_option( 'permalink_structure' ) ? get_option( 'permalink_structure' ) : 'Default';
                 $sysinfo['front_page_display']   = get_option( 'show_on_front' );

--- a/ReduxCore/inc/tracking.php
+++ b/ReduxCore/inc/tracking.php
@@ -323,7 +323,7 @@
                     'php'       => $version,
                     'site'      => array(
                         'hash'      => $this->options['hash'],
-                        'version'   => bloginfo( 'version' ),
+                        'version'   => get_bloginfo( 'version' ),
                         'multisite' => is_multisite(),
                         'users'     => $user_query->get_total(),
                         'lang'      => get_locale(),


### PR DESCRIPTION
This reverts commit 6c82407a9ffd7d1b279775985acc6a36b761fad3.

As seen in wordpress documentation the get_bloginfo is not deprecated, the "bloginfo" method just echo the get_bloginfo response, which I think is not what is needed in this part of the framework

https://developer.wordpress.org/reference/functions/bloginfo/#source-code

Thanks for the awesome work :)

Cheers! 