### PR TITLE
Add more CSS units to field_dimensions.php

### DIFF
--- a/ReduxCore/inc/fields/dimensions/field_dimensions.php
+++ b/ReduxCore/inc/fields/dimensions/field_dimensions.php
@@ -78,7 +78,12 @@
                         'pt',
                         'pc',
                         'px',
-                        'rem'
+                        'rem',
+                        'vh',
+                        'vw',
+                        'vmin',
+                        'vmax',
+                        'ch'
                     ) )
                 ) {
                     unset( $this->field['units'] );
@@ -95,7 +100,13 @@
                         'ex',
                         'pt',
                         'pc',
-                        'px'
+                        'px',
+                        'rem',
+                        'vh',
+                        'vw',
+                        'vmin',
+                        'vmax',
+                        'ch'
                     ) )
                 ) {
                     unset( $this->value['units'] );


### PR DESCRIPTION
It is time to support more CSS units.

- Added vh, vw, vmin, vmax, ch units to 'units' argument.
- Added vh, vw, vmin, vmax, ch units to 'default'->'units' argument.
- Added rem to 'default'->'units' argument. ( https://github.com/reduxframework/redux-framework/issues/2080   Now it is completely fixed. )