### PR TITLE
Add more CSS units to field_spacing.php

### DIFF
--- a/ReduxCore/inc/fields/spacing/field_spacing.php
+++ b/ReduxCore/inc/fields/spacing/field_spacing.php
@@ -79,7 +79,12 @@ if ( ! class_exists( 'ReduxFramework_spacing' ) ) {
                         'ex',
                         'pt',
                         'pc',
-                        'px'
+                        'px',
+                        'vh',
+                        'vw',
+                        'vmin',
+                        'vmax',
+                        'ch'
                     ) )
             ) {
                 unset( $this->field['units'] );
@@ -97,7 +102,12 @@ if ( ! class_exists( 'ReduxFramework_spacing' ) ) {
                         'ex',
                         'pt',
                         'pc',
-                        'px'
+                        'px',
+                        'vh',
+                        'vw',
+                        'vmin',
+                        'vmax',
+                        'ch'
                     ) )
             ) {
                 unset( $this->value['units'] );


### PR DESCRIPTION
Please make more CSS units available for the spacing field.

- Added vh, vw, vmin, vmax, ch units to 'units' argument.
- Added vh, vw, vmin, vmax, ch units to 'default'->'units' argument.