### PR TITLE
Limited checkRequired to only affecting contents inside of .redux-container

### DIFF
--- a/ReduxCore/assets/js/redux.js
+++ b/ReduxCore/assets/js/redux.js
@@ -311,7 +311,7 @@
             }
         );
 
-        $( 'td > fieldset:empty,td > div:empty' ).parent().parent().hide();
+        $( '.redux-container' ).find( 'td > fieldset:empty,td > div:empty' ).parent().parent().hide();
     };
 
     $.redux.initQtip = function() {


### PR DESCRIPTION
When Redux is used on taxonomy pages, the original selector was hiding table contents that weren't part of Redux.