### PR TITLE
Expanded units accepted by units extended

### DIFF
--- a/ReduxCore/inc/fields/dimensions/field_dimensions.php
+++ b/ReduxCore/inc/fields/dimensions/field_dimensions.php
@@ -74,11 +74,13 @@
                         'cm',
                         'mm',
                         'em',
+                        'rem',
                         'ex',
                         'pt',
                         'pc',
                         'px',
-                        'rem'
+                        'vw',
+                        'vh'
                     ) )
                 ) {
                     unset( $this->field['units'] );
@@ -87,15 +89,19 @@
                 //if there is a default unit value  but is not an accepted value, unset the variable
                 if ( isset( $this->value['units'] ) && ! Redux_Helpers::array_in_array( $this->value['units'], array(
                         '',
+                        false,
                         '%',
                         'in',
                         'cm',
                         'mm',
                         'em',
+                        'rem',
                         'ex',
                         'pt',
                         'pc',
-                        'px'
+                        'px',
+                        'vw',
+                        'vh'
                     ) )
                 ) {
                     unset( $this->value['units'] );
@@ -191,7 +197,7 @@
 
                     //  Extended units, show 'em all
                     if ( $this->field['units_extended'] ) {
-                        $testUnits = array( 'px', 'em', 'rem', '%', 'in', 'cm', 'mm', 'ex', 'pt', 'pc' );
+                        $testUnits = array( 'px', 'em', 'rem', '%', 'in', 'cm', 'mm', 'ex', 'pt', 'pc', 'vw', 'vh' );
                     } else {
                         $testUnits = array( 'px', 'em', 'rem', '%' );
                     }

--- a/ReduxCore/inc/fields/spacing/field_spacing.php
+++ b/ReduxCore/inc/fields/spacing/field_spacing.php
@@ -79,7 +79,9 @@ if ( ! class_exists( 'ReduxFramework_spacing' ) ) {
                         'ex',
                         'pt',
                         'pc',
-                        'px'
+                        'px',
+                        'vw',
+                        'vh'
                     ) )
             ) {
                 unset( $this->field['units'] );
@@ -97,7 +99,9 @@ if ( ! class_exists( 'ReduxFramework_spacing' ) ) {
                         'ex',
                         'pt',
                         'pc',
-                        'px'
+                        'px',
+                        'vw',
+                        'vh'
                     ) )
             ) {
                 unset( $this->value['units'] );
@@ -246,7 +250,7 @@ if ( ! class_exists( 'ReduxFramework_spacing' ) ) {
                 echo '<select data-placeholder="' . __( 'Units', 'redux-framework' ) . '" class="redux-spacing redux-spacing-units select ' . $this->field['class'] . '" original-title="' . __( 'Units', 'redux-framework' ) . '" name="' . $this->field['name'] . $this->field['name_suffix'] . '[units]' . '" id="' . $this->field['id'] . '_units">';
 
                 if ( $this->field['units_extended'] ) {
-                    $testUnits = array( 'px', 'em', 'rem', '%', 'in', 'cm', 'mm', 'ex', 'pt', 'pc' );
+                    $testUnits = array( 'px', 'em', 'rem', '%', 'in', 'cm', 'mm', 'ex', 'pt', 'pc', 'vw', 'vh' );
                 } else {
                     $testUnits = array( 'px', 'em', 'pt', 'rem', '%' );
                 }


### PR DESCRIPTION
* Added viewport width (vw) and viewport height (vh) to units extended.
* Normalized the units comparison arrays for dimensions and spacing fields.

We commonly use viewport width units on spacing and dimension values in CSS. I just made some slight adjustments to the arrays associated with acceptable value control for the spacing and dimension fields.