### PR TITLE
Fix: PHP Fatal Error if "redux" folder doesn't exist

### DIFF
--- a/ReduxCore/inc/class.redux_filesystem.php
+++ b/ReduxCore/inc/class.redux_filesystem.php
@@ -173,6 +173,17 @@
                     } else {
                         $chmod = 0755;
                     }
+			
+                    $upload = wp_upload_dir();
+                    $uploads_dir = $upload['basedir'] . '/redux/';
+                    do {
+			  if (!file_exists($uploads_dir)) {
+			     wp_mkdir_p( $uploads_dir );
+			     header("Refresh:0");
+			     break;
+			  }
+		    } while(true);
+			
                     $res = $wp_filesystem->mkdir( $file );
                     if ( ! $res ) {
                         wp_mkdir_p( $file );


### PR DESCRIPTION
Hi, Redux Team,

First of all, I want to let you guys know that this is my first PR on GitHub and it is quite exciting that I got a chance to submit my first PR to a WordPress Framework which is greatly used by countless websites.

There is a Fatal Php Error I have encountered while testing one of the themes I was working with and you can see the error in this screenshot http://jmp.sh/or4Wc5t

It is occurring if the folder "**redux**" is not created in **wp-content  → uploads**. I added a check if the folder doesn't exist then create it and refresh the page

Sorry, this is my first contribution so forgive me for any mistakes.

Thank you,

Usman