### PR TITLE
Fixed wp_remote_get() response

### DIFF
--- a/ReduxCore/inc/class.redux_helpers.php
+++ b/ReduxCore/inc/class.redux_helpers.php
@@ -502,9 +502,12 @@
                     if ( ! is_wp_error( $response ) && $response['response']['code'] >= 200 && $response['response']['code'] < 300 ) {
                         $sysinfo['wp_remote_get']       = 'true';
                         $sysinfo['wp_remote_get_error'] = '';
-                    } else {
+                    } elseif( is_wp_error( $response ) ) {
                         $sysinfo['wp_remote_get']       = 'false';
                         $sysinfo['wp_remote_get_error'] = $response->get_error_message();
+                    } else {
+                        $sysinfo['wp_remote_get']       = 'false';
+                        $sysinfo['wp_remote_get_error'] = $response['response']['code'] . (isset($response['response']['message']) ? $response['response']['message'] : '');
                     }
                 }
 


### PR DESCRIPTION
Fixes a fatal error where if the script receives anything not between 200-300 response but isn't a wp_error object (affects the status page).