### PR TITLE
Added viewport-based units to the dimensions field

### DIFF
--- a/ReduxCore/inc/fields/dimensions/field_dimensions.php
+++ b/ReduxCore/inc/fields/dimensions/field_dimensions.php
@@ -72,7 +72,9 @@
                         'pt',
                         'pc',
                         'px',
-                        'rem'
+                        'rem',
+                        'vw',
+                        'vh'
                     ) )
                 ) {
                     unset( $this->field['units'] );
@@ -89,7 +91,10 @@
                         'ex',
                         'pt',
                         'pc',
-                        'px'
+                        'px',
+                        'rem',
+                        'vw',
+                        'vh'
                     ) )
                 ) {
                     unset( $this->value['units'] );
@@ -185,9 +190,9 @@
 
                     //  Extended units, show 'em all
                     if ( $this->field['units_extended'] ) {
-                        $testUnits = array( 'px', 'em', 'rem', '%', 'in', 'cm', 'mm', 'ex', 'pt', 'pc' );
+                        $testUnits = array( 'px', 'em', 'rem', 'vw', 'vh', '%', 'in', 'cm', 'mm', 'ex', 'pt', 'pc' );
                     } else {
-                        $testUnits = array( 'px', 'em', 'rem', '%' );
+                        $testUnits = array( 'px', 'em', 'rem', 'vw', 'vh', '%' );
                     }
 
                     if ( $this->field['units'] != "" && is_array( $this->field['units'] ) ) {


### PR DESCRIPTION
Viewport based units are useful in some cases - eg. fullscreen banners.
Also added the missing rem unit to the defaults array.

(this is my first pull request ever. sorry in advance if i did something wrong)