### PR TITLE
Fix for a js error that can occur with some extensions

### DIFF
--- a/ReduxCore/assets/js/redux.js
+++ b/ReduxCore/assets/js/redux.js
@@ -659,7 +659,7 @@
 
                 var type = $( this ).attr( 'data-type' );
                 //console.log(type);
-                if ( typeof redux.field_objects != 'undefined' && redux.field_objects[type] && redux.field_objects[type] ) {
+                if ( type in redux.field_objects && typeof redux.field_objects[type].init == 'function' ) {
                     redux.field_objects[type].init();
                 }
                 if ( !redux.customizer && $( this ).hasClass( 'redux_remove_th' ) ) {


### PR DESCRIPTION
This line throwed a javascript error if ace_editor is present within the subfields, this takes care of it