### PR TITLE
Changing preg_replace_callback for preg_replace as this is the expectation

### DIFF
--- a/ReduxCore/inc/validation/preg_replace/validation_preg_replace.php
+++ b/ReduxCore/inc/validation/preg_replace/validation_preg_replace.php
@@ -26,7 +26,7 @@
              * @since ReduxFramework 1.0.0
              */
             function validate() {
-                $this->value = preg_replace_callback($this->field['preg']['pattern'], function($matches){return $this->field['preg']['replacement'];}, $this->value);
+                $this->value = preg_replace($this->field['preg']['pattern'], $this->field['preg']['replacement'], $this->value);
             } //function
         } //class
     }


### PR DESCRIPTION
…ed behaviour

This will not cause any BC break but adds some flexibility on the replacement (arrays for 'pattern' and 'replacement' for example) and also replacement with parts from the initial regex

This is the expected behaviour given the name of the validation function