### PR TITLE
Fix for the database mode 'options' not saving properly

### DIFF
--- a/ReduxCore/framework.php
+++ b/ReduxCore/framework.php
@@ -807,8 +807,6 @@
                             set_theme_mod( $k, $v );
                         }
                     } else if ( $this->args['database'] === 'network' ) {
-                        // Strip those slashes!
-                        $value = json_decode( stripslashes( json_encode( $value ) ), true );
                         update_site_option( $this->args['opt_name'], $value );
                     } else {
                         update_option( $this->args['opt_name'], $value );
@@ -860,7 +858,6 @@
                     $result = get_theme_mods();
                 } else if ( $this->args['database'] === 'network' ) {
                     $result = get_site_option( $this->args['opt_name'], array() );
-                    $result = json_decode( stripslashes( json_encode( $result ) ), true );
                 } else {
                     $result = get_option( $this->args['opt_name'], array() );
                 }


### PR DESCRIPTION
update_site_option and get_site_option works the same as update_option/get_option so why was this here in the first place when it's not there on the next line, I do not know..