### PR TITLE
.live replaced with .on

### DIFF
--- a/ReduxCore/inc/fields/multi_text/field_multi_text.js
+++ b/ReduxCore/inc/fields/multi_text/field_multi_text.js
@@ -28,8 +28,7 @@
                 } else {
                     return;
                 }
-                el.find( '.redux-multi-text-remove' ).live(
-                    'click', function() {
+                el.on( 'click', '.redux-multi-text-remove', function() {
                         redux_change( $( this ) );
                         
                         $( this ).prev( 'input[type="text"]' ).val( '' );


### PR DESCRIPTION
WordPress 5.5 changes require jQuery scripts to use .on instead of .live