### PR TITLE
Fix warning `Undefined index: REMOTE_ADDR`

### DIFF
--- a/ReduxCore/inc/class.redux_filesystem.php
+++ b/ReduxCore/inc/class.redux_filesystem.php
@@ -130,8 +130,9 @@
 
                 $hash_path = trailingslashit( ReduxFramework::$_upload_dir ) . 'hash';
                 if ( ! file_exists( $hash_path ) ) {
+                    $remote_addr = isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : '127.0.0.1';
                     $this->do_action( 'put_contents', $hash_path, array(
-                            'content' => md5( network_site_url() . '-' . $_SERVER['REMOTE_ADDR'] )
+                            'content' => md5( network_site_url() . '-' . $remote_addr )
                         )
                     );
                 }


### PR DESCRIPTION
When running wp-cron.php via Unix cronjob. $_SERVER['REMOTE_ADDR'] does not exist so the warning will appear.