### PR TITLE
Update class-redux-output.php

### DIFF
--- a/redux-core/inc/classes/class-redux-output.php
+++ b/redux-core/inc/classes/class-redux-output.php
@@ -152,7 +152,7 @@ if ( ! class_exists( 'Redux_Output', false ) ) {
 									}
 								}
 
-								if ( ( ( isset( $field['output'] ) && ! empty( $field['output'] ) ) || ( isset( $field['compiler'] ) && ! empty( $field['compiler'] ) ) || 'typography' === $field['type'] || 'icon_select' === $field['type'] ) ) {
+								if ( $style_data !== null && ( ( isset( $field['output'] ) && ! empty( $field['output'] ) ) || ( isset( $field['compiler'] ) && ! empty( $field['compiler'] ) ) || 'typography' === $field['type'] || 'icon_select' === $field['type'] ) ) {
 									$field_object->output( $style_data );
 								}
 								if ( isset( $field['media_query'] ) && ! empty( $field['media_query'] ) ) {


### PR DESCRIPTION
The system throwing a fatal error if style data is coming null. For example, I am using a button_set with customizer true value for trigger automatic style generation. No style data is passing and it is going null.  Screenshot: https://jmp.sh/uHXQVxP

Note; This is an important problem. Because my all customers will receive this error. I am requesting a Wordpress repo update.

Thanks