### PR TITLE
Fix error when active plugin via WP CLI

### DIFF
--- a/class-redux-framework-plugin.php
+++ b/class-redux-framework-plugin.php
@@ -274,7 +274,7 @@ if ( ! class_exists( 'Redux_Framework_Plugin', false ) ) {
 		 *
 		 * @return      void
 		 */
-		public static function activate( bool $network_wide ) {
+		public static function activate( ?bool $network_wide ) {
 			// phpcs:disable
 			//if ( function_exists( 'is_multisite' ) && is_multisite() ) {
 			//	if ( $network_wide ) {


### PR DESCRIPTION
Fatal error: Uncaught TypeError: Redux_Framework_Plugin::activate(): Argument #1 ($network_wide) must be of type bool, null given