### PR TITLE
Update class-redux-helpers.php

### DIFF
--- a/redux-core/inc/classes/class-redux-helpers.php
+++ b/redux-core/inc/classes/class-redux-helpers.php
@@ -516,7 +516,7 @@ if ( ! class_exists( 'Redux_Helpers', false ) ) {
 								continue;
 							}
 
-							if ( isset( $extension::$version ) ) {
+							if ( isset($extension) && isset( $extension::$version ) ) {
 								$extensions[ $key ] = $extension::$version;
 							} elseif ( isset( $extension->version ) ) {
 								$extensions[ $key ] = $extension->version;


### PR DESCRIPTION
$extension is returning null on the old plugin definitions and this creates a fatal error.