### PR TITLE
Add extendify fetch workflow

### DIFF
--- a/.github/workflows/fetch-extendify-latest.yml
+++ b/.github/workflows/fetch-extendify-latest.yml
@@ -1,7 +1,7 @@
 name: Fetch Extendify and create PR
 on: workflow_dispatch
 jobs:
-    Fetch and PR:
+    fetch-and-pr:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code

--- a/.github/workflows/fetch-extendify-latest.yml
+++ b/.github/workflows/fetch-extendify-latest.yml
@@ -1,0 +1,31 @@
+name: Fetch Extendify and create PR
+on: workflow_dispatch
+jobs:
+    Fetch and PR:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v2
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+            - name: Download and replace code
+              run: |
+                # 1. Clean up the existing directory
+                rm -rf ./extendify-sdk && mkdir ./extendify-sdk && mkdir ./extendify-tmp
+                # 2. Fetch from .org
+                curl -LO https://downloads.wordpress.org/plugin/extendify.latest-stable.zip
+                # 3. Unzip to temp directory
+                unzip ./extendify.latest-stable.zip -d ./extendify-tmp
+                # 4. Copy to the sdk directory
+                cp -R ./extendify-tmp/extendify/* ./extendify-sdk
+                # 5. Cleanup directories and remove zip
+                rm -rf ./extendify-tmp && rm ./extendify.latest-stable.zip
+                # 6. Remove main file header content
+                php -w ./extendify-sdk/extendify.php > ./ext.tmp && mv ./ext.tmp ./extendify-sdk/extendify.php
+            - name: Create Pull Request
+              uses: peter-evans/create-pull-request@v3
+              with:
+                commit-message: Update Extendify Library
+                title: Update Extendify Library
+                branch: update-extendify
+                branch-suffix: random


### PR DESCRIPTION
This adds an auto fetch mechanism for the extendify library. It will:

1. Fetch from .ORG
2. unzip and prep the files.
3. open a PR with the changes.

it's a manual workflow. In case you're unsure where to run it (needs to be merged into master before you can run it). It's non destructive so you can it as many times as you like. it will open a PR each time though.

![Screen Shot 2022-01-06 at 7 57 33 PM](https://user-images.githubusercontent.com/1478421/148474098-27b4621c-bf2d-471c-8d5d-381f292914c7.png)

Can you audit the script and run it after merging in? @kprovance 