### PR TITLE
Update class-redux-page-render.php

### DIFF
--- a/redux-core/inc/classes/class-redux-page-render.php
+++ b/redux-core/inc/classes/class-redux-page-render.php
@@ -950,6 +950,10 @@ if ( ! class_exists( 'Redux_Page_Render', false ) ) {
 				}
 			} else {
 				foreach ( $field['default'] as $defaultk => $defaultv ) {
+					/* avoids depreciated warnings when floating-point numbers are used as keys */
+					$defaultk = is_numeric($defaultk) ? (string) $defaultk : $defaultk;
+    				$defaultv = is_numeric($defaultv) ? (string) $defaultv : $defaultv;
+
 					if ( ! empty( $field['options'][ $defaultv ]['alt'] ) ) {
 						$default_output .= $field['options'][ $defaultv ]['alt'] . ', ';
 					} elseif ( ! empty( $field['options'][ $defaultv ] ) ) {


### PR DESCRIPTION
This resolves PHP warnings like:
Deprecated: Implicit conversion from float 0.2 to int loses precision