### PR TITLE
improve callback validation for data fetching

### DIFF
--- a/redux-core/inc/classes/class-redux-wordpress-data.php
+++ b/redux-core/inc/classes/class-redux-wordpress-data.php
@@ -471,7 +471,7 @@ if ( ! class_exists( 'Redux_WordPress_Data', false ) ) {
 					break;
 
 				case 'callback':
-					if ( ! empty( $args ) && is_string( $args ) && function_exists( $args ) ) {
+					if ( ! empty( $args ) && is_callable( $args ) ) {
 						$data = call_user_func( $args, $current_value );
 					}
 


### PR DESCRIPTION
briefly:
- Replace complex condition with [`is_callable`](https://www.php.net/manual/en/function.is-callable.php)
- Ensure private/protected methods are handled correctly, since it was not even calling class methods.



long:

The Class" Redux_WordPress_Data" in '\redux-framework\redux-core\inc\classes\class-redux-wordpress-data.php', which populate some fields, is not calling class methods/callable arrays when its type is set to 'callback' and the 'args' value is the callable array.


on '\redux-framework\redux-core\inc\classes\class-redux-wordpress-data.php' , on the `switch($type)` statement, line 473, we have:

``` 
case 'callback':
					if ( ! empty( $args ) && is_string( $args ) && function_exists( $args ) ) {
						$data = call_user_func( $args, $current_value );
					}

					break;
 ```

which conditions does not include callable arrays, like the ones mentioned in Example 2 in [this php doc](https://www.php.net/manual/en/function.is-callable.php)


I don't know if originally it shouldn't call methods/arrays as custom callbacks, but since it is common to use callbacks in this format, it can be useful to include this.