### PR TITLE
Fixed string translation in class-redux-args.php

### DIFF
--- a/redux-core/inc/classes/class-redux-args.php
+++ b/redux-core/inc/classes/class-redux-args.php
@@ -266,7 +266,7 @@ if ( ! class_exists( 'Redux_Args', false ) ) {
 				/* translators: 1: Redux, 2: Link to plugin review */
 					__( 'Enjoyed %1$s? Please leave us a %2$s. We really appreciate your support!', 'redux-framework' ),
 					'<strong>' . __( 'Redux', 'redux-framework' ) . '</strong>',
-					'<a href="https://wordpress.org/support/plugin/redux-framework/reviews/#new-post" target="_blank">review</a>'
+					'<a href="https://wordpress.org/support/plugin/redux-framework/reviews/#new-post" target="_blank">' . __( 'review', 'redux-framework' ) . '</a>'
 				);
 				$args['footer_credit'] = '<span id="footer-thankyou">' . $footer_text . '</span>';
 			}


### PR DESCRIPTION
Fixed string translation in class-redux-args.php

See: https://wordpress.org/support/topic/this-string-is-hardcoded-and-cannot-be-translated-10/